### PR TITLE
[PC-203] Google Oauth 인증 IdToken 인증하는 로직으로 변경

### DIFF
--- a/api/src/main/java/org/yapp/domain/auth/api/LoginController.java
+++ b/api/src/main/java/org/yapp/domain/auth/api/LoginController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.yapp.domain.auth.application.oauth.service.OauthService;
 import org.yapp.domain.auth.dto.request.OauthLoginRequest;
 import org.yapp.domain.auth.dto.response.OauthLoginResponse;
-import org.yapp.util.ApiResponse;
+import org.yapp.util.CommonResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,18 +19,18 @@ import lombok.RequiredArgsConstructor;
 public class LoginController {
   private final OauthService oauthService;
 
-  @PostMapping("/oauth")
-  public ResponseEntity<ApiResponse<OauthLoginResponse>> oauthLogin(@RequestBody OauthLoginRequest request) {
-    OauthLoginResponse response = oauthService.login(request);
-    return ResponseEntity.ok(ApiResponse.createSuccess(response));
-  }
-
   /**
    * 개발중 소셜 로그인으로 사용자으 accessToken을 가져오기 어렵기 때문에 만든 임시 메서드
    */
   @PostMapping("/test/users/{userId}")
-  public ResponseEntity<ApiResponse<OauthLoginResponse>> getToken(@PathVariable Long userId) {
+  public ResponseEntity<CommonResponse<OauthLoginResponse>> getToken(@PathVariable Long userId) {
     OauthLoginResponse response = oauthService.tmpTokenGet(userId);
-    return ResponseEntity.ok(ApiResponse.createSuccess(response));
+    return ResponseEntity.ok(CommonResponse.createSuccess(response));
+  }
+
+  @PostMapping("/oauth")
+  public ResponseEntity<CommonResponse<OauthLoginResponse>> oauthLogin(@RequestBody OauthLoginRequest request) {
+    OauthLoginResponse response = oauthService.login(request);
+    return ResponseEntity.ok(CommonResponse.createSuccess(response));
   }
 }

--- a/api/src/main/java/org/yapp/domain/auth/application/oauth/google/GoogleOauthClient.java
+++ b/api/src/main/java/org/yapp/domain/auth/application/oauth/google/GoogleOauthClient.java
@@ -2,10 +2,7 @@ package org.yapp.domain.auth.application.oauth.google;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
-import com.google.api.client.http.javanet.NetHttpTransport;
-import com.google.api.client.json.jackson2.JacksonFactory;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.yapp.domain.auth.application.oauth.OauthClient;
 import org.yapp.error.code.auth.AuthErrorCode;
@@ -13,25 +10,20 @@ import org.yapp.error.exception.ApplicationException;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.util.Collections;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class GoogleOauthClient implements OauthClient {
-  @Value("${app.google.client.id}")
-  private String googleClientId;
+  private final GoogleIdTokenVerifier googleIdTokenVerifier;
 
   @Override
   public String getOAuthProviderUserId(String token) {
     GoogleIdToken googleIdToken;
 
-    GoogleIdTokenVerifier verifier =
-        new GoogleIdTokenVerifier.Builder(new NetHttpTransport(), JacksonFactory.getDefaultInstance()).setAudience(
-            Collections.singletonList(googleClientId)).build();
     try {
-      googleIdToken = verifier.verify(token);
+      googleIdToken = googleIdTokenVerifier.verify(token);
     } catch (GeneralSecurityException e) {
       throw new ApplicationException(AuthErrorCode.OAUTH_ERROR);
     } catch (IOException e) {

--- a/api/src/main/java/org/yapp/domain/auth/application/oauth/google/GoogleOauthClient.java
+++ b/api/src/main/java/org/yapp/domain/auth/application/oauth/google/GoogleOauthClient.java
@@ -1,34 +1,45 @@
 package org.yapp.domain.auth.application.oauth.google;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import lombok.RequiredArgsConstructor;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.jackson2.JacksonFactory;
+
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestTemplate;
 import org.yapp.domain.auth.application.oauth.OauthClient;
+import org.yapp.error.code.auth.AuthErrorCode;
+import org.yapp.error.exception.ApplicationException;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Collections;
+
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class GoogleOauthClient implements OauthClient {
-    @Value("${oauth.googleUserInfoUri}")
-    private String userInfoUri;
-    private final RestTemplate restTemplate;
+  @Value("${app.google.client.id}")
+  private String googleClientId;
 
-    @Override
-    public String getOAuthProviderUserId(String accessToken) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + accessToken);
-        HttpEntity<Object> entity = new HttpEntity<>(headers);
+  @Override
+  public String getOAuthProviderUserId(String token) {
+    GoogleIdToken googleIdToken;
 
-        ResponseEntity<JsonNode> response = restTemplate.exchange(
-                userInfoUri, HttpMethod.GET, entity, JsonNode.class);
-        if (response.getStatusCode().is2xxSuccessful()) {
-            return response.getBody().get("sub").asText();
-        }
-        throw new RuntimeException();
+    GoogleIdTokenVerifier verifier =
+        new GoogleIdTokenVerifier.Builder(new NetHttpTransport(), JacksonFactory.getDefaultInstance()).setAudience(
+            Collections.singletonList(googleClientId)).build();
+    try {
+      googleIdToken = verifier.verify(token);
+    } catch (GeneralSecurityException e) {
+      throw new ApplicationException(AuthErrorCode.OAUTH_ERROR);
+    } catch (IOException e) {
+      throw new ApplicationException(AuthErrorCode.OAUTH_ERROR);
     }
+    if (googleIdToken == null) {
+      throw new ApplicationException(AuthErrorCode.OAUTH_ERROR);
+    }
+    return googleIdToken.getPayload().getSubject();
+  }
 }

--- a/api/src/main/java/org/yapp/domain/auth/application/oauth/service/OauthService.java
+++ b/api/src/main/java/org/yapp/domain/auth/application/oauth/service/OauthService.java
@@ -4,8 +4,8 @@ import org.springframework.stereotype.Service;
 import org.yapp.domain.auth.application.jwt.JwtUtil;
 import org.yapp.domain.auth.application.oauth.OauthProvider;
 import org.yapp.domain.auth.application.oauth.OauthProviderResolver;
-import org.yapp.domain.auth.dto.request.OauthLoginRequest;
-import org.yapp.domain.auth.dto.response.OauthLoginResponse;
+import org.yapp.domain.auth.presentation.dto.request.OauthLoginRequest;
+import org.yapp.domain.auth.presentation.dto.response.OauthLoginResponse;
 import org.yapp.domain.user.User;
 import org.yapp.domain.user.dao.UserRepository;
 

--- a/api/src/main/java/org/yapp/domain/auth/presentation/LoginController.java
+++ b/api/src/main/java/org/yapp/domain/auth/presentation/LoginController.java
@@ -1,4 +1,4 @@
-package org.yapp.domain.auth.api;
+package org.yapp.domain.auth.presentation;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -7,8 +7,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.yapp.domain.auth.application.oauth.service.OauthService;
-import org.yapp.domain.auth.dto.request.OauthLoginRequest;
-import org.yapp.domain.auth.dto.response.OauthLoginResponse;
+import org.yapp.domain.auth.presentation.dto.request.OauthLoginRequest;
+import org.yapp.domain.auth.presentation.dto.response.OauthLoginResponse;
 import org.yapp.util.CommonResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -20,7 +20,7 @@ public class LoginController {
   private final OauthService oauthService;
 
   /**
-   * 개발중 소셜 로그인으로 사용자으 accessToken을 가져오기 어렵기 때문에 만든 임시 메서드
+   * 개발중 소셜 로그인으로 사용자의 accessToken을 가져오기 어렵기 때문에 만든 임시 메서드
    */
   @PostMapping("/test/users/{userId}")
   public ResponseEntity<CommonResponse<OauthLoginResponse>> getToken(@PathVariable Long userId) {

--- a/api/src/main/java/org/yapp/domain/auth/presentation/dto/request/OauthLoginRequest.java
+++ b/api/src/main/java/org/yapp/domain/auth/presentation/dto/request/OauthLoginRequest.java
@@ -1,4 +1,4 @@
-package org.yapp.domain.auth.dto.request;
+package org.yapp.domain.auth.presentation.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/api/src/main/java/org/yapp/domain/auth/presentation/dto/response/OauthLoginResponse.java
+++ b/api/src/main/java/org/yapp/domain/auth/presentation/dto/response/OauthLoginResponse.java
@@ -1,4 +1,4 @@
-package org.yapp.domain.auth.dto.response;
+package org.yapp.domain.auth.presentation.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 public class OauthLoginResponse {
-    private boolean registered;
-    private String accessToken;
-    private String refreshToken;
+  private boolean registered;
+  private String accessToken;
+  private String refreshToken;
 }

--- a/api/src/main/java/org/yapp/domain/auth/presentation/dto/response/OauthUserInfoResponse.java
+++ b/api/src/main/java/org/yapp/domain/auth/presentation/dto/response/OauthUserInfoResponse.java
@@ -1,4 +1,4 @@
-package org.yapp.domain.auth.dto.response;
+package org.yapp.domain.auth.presentation.dto.response;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -6,5 +6,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 public class OauthUserInfoResponse {
-    private String id;
+  private String id;
 }

--- a/api/src/main/java/org/yapp/domain/profile/api/ProfileController.java
+++ b/api/src/main/java/org/yapp/domain/profile/api/ProfileController.java
@@ -14,7 +14,7 @@ import org.yapp.domain.profile.api.response.ProfileResponse;
 import org.yapp.domain.profile.application.ProfileService;
 import org.yapp.domain.user.User;
 import org.yapp.domain.user.application.UserService;
-import org.yapp.util.ApiResponse;
+import org.yapp.util.CommonResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -32,18 +32,18 @@ public class ProfileController {
   @GetMapping
   @Operation(summary = "프로필 조회", description = "현재 로그인된 사용자의 프로필을 조회합니다.", tags = {"Profile"})
   @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "프로필이 성공적으로 조회되었습니다.")
-  public ResponseEntity<ApiResponse<ProfileResponse>> updateProfile(@AuthenticationPrincipal Long userId) {
+  public ResponseEntity<CommonResponse<ProfileResponse>> updateProfile(@AuthenticationPrincipal Long userId) {
     User user = userService.getUserById(userId);
     return ResponseEntity.status(HttpStatus.OK)
-                         .body(ApiResponse.createSuccess(ProfileResponse.from(user.getProfile())));
+                         .body(CommonResponse.createSuccess(ProfileResponse.from(user.getProfile())));
   }
 
   @PutMapping()
   @Operation(summary = "프로필 업데이트", description = "현재 로그인된 사용자의 프로필을 업데이트합니다.", tags = {"Profile"})
   @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "프로필이 성공적으로 업데이트되었습니다.")
-  public ResponseEntity<ApiResponse<ProfileResponse>> updateProfile(@AuthenticationPrincipal Long userId,
+  public ResponseEntity<CommonResponse<ProfileResponse>> updateProfile(@AuthenticationPrincipal Long userId,
       @RequestBody @Valid ProfileUpdateRequest request) {
     Profile profile = profileService.updateByUserId(userId, request);
-    return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.createSuccess(ProfileResponse.from(profile)));
+    return ResponseEntity.status(HttpStatus.OK).body(CommonResponse.createSuccess(ProfileResponse.from(profile)));
   }
 }

--- a/api/src/main/java/org/yapp/domain/value/presentation/ValueItemController.java
+++ b/api/src/main/java/org/yapp/domain/value/presentation/ValueItemController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.yapp.domain.value.ValueItem;
 import org.yapp.domain.value.application.ValueItemService;
 import org.yapp.domain.value.presentation.dto.ValueItemResponses;
-import org.yapp.util.ApiResponse;
+import org.yapp.util.CommonResponse;
 
 import java.util.List;
 
@@ -24,8 +24,9 @@ public class ValueItemController {
   @GetMapping()
   @Operation(summary = "가치관 질문 리스트 조회", description = "서비스에 등록된 모든 가치관 질문을 조회합니다.", tags = {"ValueItem"})
   @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "가치관 리스트가 성공적으로 조회되었습니다.")
-  public ResponseEntity<ApiResponse<ValueItemResponses>> getValueItems() {
+  public ResponseEntity<CommonResponse<ValueItemResponses>> getValueItems() {
     List<ValueItem> allValueItems = valueItemService.getAllValueItems();
-    return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.createSuccess(ValueItemResponses.from(allValueItems)));
+    return ResponseEntity.status(HttpStatus.OK)
+                         .body(CommonResponse.createSuccess(ValueItemResponses.from(allValueItems)));
   }
 }

--- a/api/src/main/java/org/yapp/global/config/GoogleOauthConfig.java
+++ b/api/src/main/java/org/yapp/global/config/GoogleOauthConfig.java
@@ -1,0 +1,26 @@
+package org.yapp.global.config;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.jackson2.JacksonFactory;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Collections;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class GoogleOauthConfig {
+  @Value("${app.google.client.id}")
+  private String googleClientId;
+
+  @Bean
+  public GoogleIdTokenVerifier googleIdTokenVerifier() {
+    return new GoogleIdTokenVerifier.Builder(new NetHttpTransport(), JacksonFactory.getDefaultInstance()).setAudience(
+        Collections.singletonList(googleClientId)).build();
+  }
+}

--- a/api/src/test/java/org/yapp/domain/auth/application/oauth/service/OauthServiceTest.java
+++ b/api/src/test/java/org/yapp/domain/auth/application/oauth/service/OauthServiceTest.java
@@ -10,8 +10,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.yapp.domain.auth.application.jwt.JwtUtil;
 import org.yapp.domain.auth.application.oauth.OauthProvider;
 import org.yapp.domain.auth.application.oauth.OauthProviderResolver;
-import org.yapp.domain.auth.dto.request.OauthLoginRequest;
-import org.yapp.domain.auth.dto.response.OauthLoginResponse;
+import org.yapp.domain.auth.presentation.dto.request.OauthLoginRequest;
+import org.yapp.domain.auth.presentation.dto.response.OauthLoginResponse;
 import org.yapp.domain.user.User;
 import org.yapp.domain.user.dao.UserRepository;
 
@@ -63,6 +63,21 @@ class OauthServiceTest {
   }
 
   @Test
+  @DisplayName("존재하지 않는 Provider로 로그인을 요청하여 로그인에 실패한다.")
+  void testLogin_Failure() {
+    // Given
+    String providerName = "nonexistent";
+    String token = "oauth_token";
+    OauthLoginRequest request = new OauthLoginRequest(providerName, token);
+
+    // Mocking
+    when(oauthProviderResolver.find(providerName)).thenThrow(new RuntimeException());
+
+    // When & Then
+    assertThrows(RuntimeException.class, () -> oauthService.login(request));
+  }
+
+  @Test
   @DisplayName("회원가입이 된 상태에서 로그인에 성공하여 액세스, 리프레시 토큰을 반환한다.")
   void testNotFirstLogin_Success() {
     //given
@@ -86,20 +101,5 @@ class OauthServiceTest {
     assertThat(response.isRegistered()).isFalse();
     assertThat(response.getAccessToken()).isEqualTo("access_token");
     assertThat(response.getRefreshToken()).isEqualTo("refresh_token");
-  }
-
-  @Test
-  @DisplayName("존재하지 않는 Provider로 로그인을 요청하여 로그인에 실패한다.")
-  void testLogin_Failure() {
-    // Given
-    String providerName = "nonexistent";
-    String token = "oauth_token";
-    OauthLoginRequest request = new OauthLoginRequest(providerName, token);
-
-    // Mocking
-    when(oauthProviderResolver.find(providerName)).thenThrow(new RuntimeException());
-
-    // When & Then
-    assertThrows(RuntimeException.class, () -> oauthService.login(request));
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,11 @@ subprojects {
 		runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 		runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+		//google id token
+		implementation 'com.google.api-client:google-api-client:1.32.1'
+		implementation 'com.google.oauth-client:google-oauth-client:1.32.1'
+		implementation 'com.google.http-client:google-http-client-jackson2:1.40.1'
+
 		compileOnly 'org.projectlombok:lombok'
 		runtimeOnly 'com.mysql:mysql-connector-j'
 		annotationProcessor 'org.projectlombok:lombok'

--- a/common/src/main/java/org/yapp/error/code/auth/AuthErrorCode.java
+++ b/common/src/main/java/org/yapp/error/code/auth/AuthErrorCode.java
@@ -1,0 +1,17 @@
+package org.yapp.error.code.auth;
+
+import org.springframework.http.HttpStatus;
+import org.yapp.error.dto.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+  OAUTH_ERROR(HttpStatus.FORBIDDEN, "Oauth Error"),
+  ;
+
+  private final HttpStatus httpStatus;
+  private final String message;
+}

--- a/common/src/main/java/org/yapp/util/CommonResponse.java
+++ b/common/src/main/java/org/yapp/util/CommonResponse.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ApiResponse<T> {
+public class CommonResponse<T> {
   private static final String SUCCESS_STATUS = "success";
   private static final String FAIL_STATUS = "fail";
   private static final String ERROR_STATUS = "error";
@@ -23,17 +23,17 @@ public class ApiResponse<T> {
   private String message;
   private T data;
 
-  private ApiResponse(String status, T data, String message) {
+  private CommonResponse(String status, T data, String message) {
     this.status = status;
     this.data = data;
     this.message = message;
   }
 
-  public static ApiResponse<?> createError(String message) {
-    return new ApiResponse<>(ERROR_STATUS, null, message);
+  public static CommonResponse<?> createError(String message) {
+    return new CommonResponse<>(ERROR_STATUS, null, message);
   }
 
-  public static ApiResponse<?> createFail(BindingResult bindingResult) {
+  public static CommonResponse<?> createFail(BindingResult bindingResult) {
     Map<String, String> errors = new HashMap<>();
 
     List<ObjectError> allErrors = bindingResult.getAllErrors();
@@ -44,14 +44,14 @@ public class ApiResponse<T> {
         errors.put(error.getObjectName(), error.getDefaultMessage());
       }
     }
-    return new ApiResponse<>(FAIL_STATUS, errors, null);
+    return new CommonResponse<>(FAIL_STATUS, errors, null);
   }
 
-  public static <T> ApiResponse<T> createSuccess(T data) {
-    return new ApiResponse<>(SUCCESS_STATUS, data, "요청이 성공적으로 처리되었습니다.");
+  public static <T> CommonResponse<T> createSuccess(T data) {
+    return new CommonResponse<>(SUCCESS_STATUS, data, "요청이 성공적으로 처리되었습니다.");
   }
 
-  public static ApiResponse<?> createSuccessWithNoContent() {
-    return new ApiResponse<>(SUCCESS_STATUS, null, null);
+  public static CommonResponse<?> createSuccessWithNoContent() {
+    return new CommonResponse<>(SUCCESS_STATUS, null, null);
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-203](https://yapp25app3.atlassian.net/browse/PC-203)
## ✨ 작업 내용
- google oauth client 라이브러리 추가
- google oauth 인증 방식 변경
    - 액세스 토큰 방식 -> IdToken 방식
- OauthErrorCode 추가
- ApiResponse 객체 이름 변경 -> CommonResponse
## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항

## 📋 참고 사항
- ApiResponse 클래스가 Swagger 에서 사용하는 클래스의 이름과 같아서 CommonResponse 로 변경하였습니다.

[PC-203]: https://yapp25app3.atlassian.net/browse/PC-203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ