### PR TITLE
[PC-71] 프로필 가치관 업데이트 기능

### DIFF
--- a/api/src/main/java/org/yapp/domain/profile/application/ProfileService.java
+++ b/api/src/main/java/org/yapp/domain/profile/application/ProfileService.java
@@ -5,9 +5,12 @@ import org.springframework.transaction.annotation.Transactional;
 import org.yapp.domain.profile.Profile;
 import org.yapp.domain.profile.ProfileBasic;
 import org.yapp.domain.profile.ProfileBio;
+import org.yapp.domain.profile.ProfileValue;
 import org.yapp.domain.profile.presentation.request.ProfileUpdateRequest;
 import org.yapp.domain.profile.application.dto.ProfileCreateDto;
 import org.yapp.domain.profile.dao.ProfileRepository;
+import org.yapp.domain.profile.presentation.request.ProfileValuePair;
+import org.yapp.domain.profile.presentation.request.ProfileValueUpdateRequest;
 import org.yapp.domain.user.User;
 import org.yapp.domain.user.application.UserService;
 import org.yapp.error.dto.ProfileErrorCode;
@@ -15,19 +18,28 @@ import org.yapp.error.exception.ApplicationException;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 @Service
 @RequiredArgsConstructor
 public class ProfileService {
   private final UserService userService;
+  private final ProfileValueService profileValueService;
   private final ProfileRepository profileRepository;
 
   @Transactional
   public Profile create(ProfileCreateDto dto) {
     ProfileBasic profileBasic = ProfileBasic.builder().nickname(dto.nickName()).phoneNumber(dto.phoneNumber()).build();
     ProfileBio profileBio = ProfileBio.builder().build();
-    Profile profile = Profile.builder().profileBasic(profileBasic).profileBio(profileBio).build();
 
-    return profileRepository.save(profile);
+    Profile profile = Profile.builder().profileBasic(profileBasic).profileBio(profileBio).build();
+    Profile savedProfile = profileRepository.save(profile);
+    List<ProfileValue> allProfileValues = profileValueService.createAllProfileValues(savedProfile.getId());
+    savedProfile.updateProfileValues(allProfileValues);
+
+    return savedProfile;
   }
 
   @Transactional
@@ -46,6 +58,29 @@ public class ProfileService {
 
     profile.updateBasic(profileBasic);
     profile.updateBio(profileBio);
+
+    return profile;
+  }
+
+  @Transactional
+  public Profile updateProfileValues(long userId, ProfileValueUpdateRequest dto) {
+    User user = this.userService.getUserById(userId);
+    Profile profile = getProfileById(user.getProfile().getId());
+
+    List<ProfileValue> profileValues = profile.getProfileValues();
+
+    Map<Long, Integer> userValueItemAnswerMap = new HashMap<>();
+    for (ProfileValuePair profileValuePair : dto.profileValuePairs()) {
+      final Long valueItemId = profileValuePair.valueItemId();
+      final Integer selectedAnswer = profileValuePair.selectedAnswer();
+
+      userValueItemAnswerMap.put(valueItemId, selectedAnswer);
+    }
+
+    for (ProfileValue profileValue : profileValues) {
+      final Long profileValueItemID = profileValue.getValueItem().getId();
+      profileValue.updatedSelectedAnswer(userValueItemAnswerMap.get(profileValueItemID));
+    }
 
     return profile;
   }

--- a/api/src/main/java/org/yapp/domain/profile/dao/ProfileValueRepository.java
+++ b/api/src/main/java/org/yapp/domain/profile/dao/ProfileValueRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import org.yapp.domain.profile.ProfileValue;
 
+import java.util.List;
+
 @Repository
 public interface ProfileValueRepository extends JpaRepository<ProfileValue, Long> {
+    List<ProfileValue> findByProfileId(Long profileId);
 }

--- a/api/src/main/java/org/yapp/domain/profile/presentation/ProfileController.java
+++ b/api/src/main/java/org/yapp/domain/profile/presentation/ProfileController.java
@@ -1,5 +1,6 @@
 package org.yapp.domain.profile.presentation;
 
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.yapp.domain.profile.Profile;
 import org.yapp.domain.profile.presentation.request.ProfileUpdateRequest;
+import org.yapp.domain.profile.presentation.request.ProfileValueUpdateRequest;
 import org.yapp.domain.profile.presentation.response.ProfileResponse;
 import org.yapp.domain.profile.application.ProfileService;
 import org.yapp.domain.user.User;
@@ -31,7 +33,7 @@ public class ProfileController {
 
   @GetMapping
   @Operation(summary = "프로필 조회", description = "현재 로그인된 사용자의 프로필을 조회합니다.", tags = {"Profile"})
-  @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "프로필이 성공적으로 조회되었습니다.")
+  @ApiResponse(responseCode = "200", description = "프로필이 성공적으로 조회되었습니다.")
   public ResponseEntity<CommonResponse<ProfileResponse>> updateProfile(@AuthenticationPrincipal Long userId) {
     User user = userService.getUserById(userId);
     return ResponseEntity.status(HttpStatus.OK)
@@ -40,10 +42,21 @@ public class ProfileController {
 
   @PutMapping()
   @Operation(summary = "프로필 업데이트", description = "현재 로그인된 사용자의 프로필을 업데이트합니다.", tags = {"Profile"})
-  @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "프로필이 성공적으로 업데이트되었습니다.")
+  @ApiResponse(responseCode = "200", description = "프로필이 성공적으로 업데이트되었습니다.")
   public ResponseEntity<CommonResponse<ProfileResponse>> updateProfile(@AuthenticationPrincipal Long userId,
       @RequestBody @Valid ProfileUpdateRequest request) {
     Profile profile = profileService.updateByUserId(userId, request);
+    return ResponseEntity.status(HttpStatus.OK).body(CommonResponse.createSuccess(ProfileResponse.from(profile)));
+  }
+
+  @PutMapping("/values")
+  @Operation(summary = "프로필 가치관 업데이트", description = "현재 로그인된 사용자의 프로필 가치관을 업데이트합니다.", tags = {"ProfileValue"})
+  @ApiResponse(responseCode = "200", description = "프로필 가치관이 성공적으로 업데이트되었습니다.")
+  public ResponseEntity<CommonResponse<ProfileResponse>> updateProfileValues(
+          @AuthenticationPrincipal Long userId,
+          @RequestBody @Valid ProfileValueUpdateRequest request
+  ){
+    Profile profile = profileService.updateProfileValues(userId, request);
     return ResponseEntity.status(HttpStatus.OK).body(CommonResponse.createSuccess(ProfileResponse.from(profile)));
   }
 }

--- a/api/src/main/java/org/yapp/domain/profile/presentation/request/ProfileValuePair.java
+++ b/api/src/main/java/org/yapp/domain/profile/presentation/request/ProfileValuePair.java
@@ -1,0 +1,4 @@
+package org.yapp.domain.profile.presentation.request;
+
+public record ProfileValuePair(Long valueItemId, Integer selectedAnswer) {
+}

--- a/api/src/main/java/org/yapp/domain/profile/presentation/request/ProfileValueUpdateRequest.java
+++ b/api/src/main/java/org/yapp/domain/profile/presentation/request/ProfileValueUpdateRequest.java
@@ -1,0 +1,5 @@
+package org.yapp.domain.profile.presentation.request;
+
+import java.util.List;
+public record ProfileValueUpdateRequest(List<ProfileValuePair> profileValuePairs) {
+}

--- a/api/src/test/java/org/yapp/domain/auth/application/profile/ProfileServiceTest.java
+++ b/api/src/test/java/org/yapp/domain/auth/application/profile/ProfileServiceTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+import org.yapp.domain.auth.application.dummy.TestDataService;
 import org.yapp.domain.profile.Profile;
+import org.yapp.domain.profile.dao.ProfileValueRepository;
 import org.yapp.domain.profile.presentation.request.ProfileUpdateRequest;
 import org.yapp.domain.profile.application.ProfileService;
 import org.yapp.domain.profile.application.dto.ProfileCreateDto;
@@ -29,6 +31,12 @@ class ProfileServiceTest {
   @Autowired
   private UserRepository userRepository;
 
+  @Autowired
+  private TestDataService testDataService;
+
+  @Autowired
+  private ProfileValueRepository profileValueRepository;
+
   private User testUser;
   private Profile testProfile;
 
@@ -43,6 +51,7 @@ class ProfileServiceTest {
 
     testUser.setProfile(testProfile);
     userRepository.save(testUser);
+    testDataService.createValueItems();
   }
 
   @Test
@@ -58,6 +67,7 @@ class ProfileServiceTest {
     assertThat(savedProfile).isNotNull();
     assertThat(savedProfile.getProfileBasic().getNickname()).isEqualTo("nickname123");
     assertThat(savedProfile.getProfileBasic().getPhoneNumber()).isEqualTo("010-1234-5678");
+    assertThat(savedProfile.getProfileValues().size()).isEqualTo(profileValueRepository.count());
   }
 
   @Test
@@ -65,8 +75,8 @@ class ProfileServiceTest {
   void shouldUpdateProfileByUserId() {
     // Given: 업데이트 요청 생성
     ProfileUpdateRequest updateRequest =
-        new ProfileUpdateRequest("updatedNickname", "1995-05-20", 172, "개발자", "서울시 강남구", "비흡연", "기독교", "활발",
-            "01011112222", "https://example.com/profile.jpg", "안녕하세요. 개발자입니다.", "10년 안에 CTO가 되는 것", "기술, 클라이밍, 여행");
+            new ProfileUpdateRequest("updatedNickname", "1995-05-20", 172, "개발자", "서울시 강남구", "비흡연", "기독교", "활발",
+                    "01011112222", "https://example.com/profile.jpg", "안녕하세요. 개발자입니다.", "10년 안에 CTO가 되는 것", "기술, 클라이밍, 여행");
 
     // When: 업데이트 실행
     Profile updatedProfile = profileService.updateByUserId(testUser.getId(), updateRequest);

--- a/common/src/main/java/org/yapp/domain/profile/Profile.java
+++ b/common/src/main/java/org/yapp/domain/profile/Profile.java
@@ -50,4 +50,6 @@ public class Profile {
   public void updateBasic(ProfileBasic profileBasic) {
     this.profileBasic = profileBasic;
   }
+
+  public void updateProfileValues(List<ProfileValue> profileValues) {this.profileValues = profileValues;}
 }

--- a/common/src/main/java/org/yapp/domain/profile/ProfileValue.java
+++ b/common/src/main/java/org/yapp/domain/profile/ProfileValue.java
@@ -42,4 +42,11 @@ public class ProfileValue {
     this.valueItem = valueItem;
     this.selectedAnswer = selectedAnswer;
   }
+
+  public void updatedSelectedAnswer(Integer newSelectedAnswer) {
+    if (newSelectedAnswer == null || newSelectedAnswer <= 0)
+      throw new IllegalArgumentException("선택된 항목은 1 이상이어야 합니다.");
+
+    this.selectedAnswer = newSelectedAnswer;
+  }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-71](https://yapp25app3.atlassian.net/browse/PC-71)

## ✨ 작업 내용
- 프로필 가치관 업데이트 기능 개발
- 프로필 가치관 업데이트 기능 테스트

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항
이번에 테스트를 위한 DB로 H2를 적용하려고 했는데 문제가 생겼습니다..  ValueItem 엔티티에 Json 매핑용 Map 타입을 사용하는데 MySQL 에서는 호환 가능하지만 H2에서는 호환이 안됩니다..
H2를 위해서는  필드 타입을 Map이 아닌 String으로 변환하고 직접 컨버팅 하는 방식으로 수정이 필요할 것 같습니다. 다른 방식으로는 인메모리 DB가 아닌 외부 MySQL DB를 테스트 용으로 구축하는 방안도 있을 것 같습니다.  

## 📋 참고 사항
- 코드 리뷰 시 논의가 필요한 사항이나 배포 관련 주의 사항을 추가합니다.


[PC-71]: https://yapp25app3.atlassian.net/browse/PC-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ