### PR TITLE
[PC-197] 약관 기능

### DIFF
--- a/api/src/main/java/org/yapp/domain/term/applicatoin/TermService.java
+++ b/api/src/main/java/org/yapp/domain/term/applicatoin/TermService.java
@@ -1,0 +1,20 @@
+package org.yapp.domain.term.applicatoin;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.yapp.domain.term.Term;
+import org.yapp.domain.term.dao.TermRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TermService {
+    private final TermRepository termRepository;
+
+    @Transactional(readOnly = true)
+    public List<Term> getAllActiveTerms() {
+        return  termRepository.findAllByIsActiveTrue();
+    }
+}

--- a/api/src/main/java/org/yapp/domain/term/applicatoin/TermUseCase.java
+++ b/api/src/main/java/org/yapp/domain/term/applicatoin/TermUseCase.java
@@ -1,0 +1,58 @@
+package org.yapp.domain.term.applicatoin;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.yapp.domain.term.TermAgreement;
+import org.yapp.domain.term.applicatoin.dto.SignupTermsDto;
+import org.yapp.domain.term.dao.TermAgreementRepository;
+import org.yapp.domain.term.dao.TermRepository;
+import org.yapp.domain.user.User;
+import org.yapp.domain.user.application.UserService;
+import org.yapp.error.dto.TermErrorCode;
+import org.yapp.error.exception.ApplicationException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TermUseCase {
+    private final TermRepository termRepository;
+    private final TermAgreementRepository termAgreementRepository;
+    private final UserService userService;
+
+    @Transactional
+    public void checkTermConstraints(SignupTermsDto dto) {
+        List<Long> requiredTermIds = termRepository.findRequiredActiveTermIds();
+        List<Long> agreedTermIds = dto.agreedTermsId();
+
+        boolean hasAgreedToAllRequired = agreedTermIds.containsAll(requiredTermIds);
+
+        if (!hasAgreedToAllRequired) {
+            throw new IllegalStateException("모든 필수 약관에 동의해야 회원가입이 가능합니다.");
+        }
+
+        User user = userService.getUserById(dto.userId());
+
+        List<Long> alreadyAgreedTermIds = termAgreementRepository.findByUserId(user.getId())
+                .stream()
+                .map(agreement -> agreement.getTerm().getId())
+                .toList();
+
+        List<Long> newAgreementTermIds = agreedTermIds.stream()
+                .filter(termId -> !alreadyAgreedTermIds.contains(termId))
+                .toList();
+
+        List<TermAgreement> agreements = newAgreementTermIds.stream()
+                .map(termId -> TermAgreement.builder()
+                        .user(user)
+                        .term(termRepository.findById(termId)
+                                .orElseThrow(() -> new ApplicationException(TermErrorCode.NOTFOUND_TERM)))
+                        .agreedAt(LocalDateTime.now())
+                        .build())
+                .toList();
+
+        termAgreementRepository.saveAll(agreements);
+    }
+}

--- a/api/src/main/java/org/yapp/domain/term/applicatoin/dto/SignupTermsDto.java
+++ b/api/src/main/java/org/yapp/domain/term/applicatoin/dto/SignupTermsDto.java
@@ -1,0 +1,9 @@
+package org.yapp.domain.term.applicatoin.dto;
+
+import java.util.List;
+
+public record SignupTermsDto (
+        Long userId,
+        List<Long> agreedTermsId
+){
+}

--- a/api/src/main/java/org/yapp/domain/term/dao/TermAgreementRepository.java
+++ b/api/src/main/java/org/yapp/domain/term/dao/TermAgreementRepository.java
@@ -1,0 +1,12 @@
+package org.yapp.domain.term.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.yapp.domain.term.TermAgreement;
+
+import java.util.List;
+
+@Repository
+public interface TermAgreementRepository extends JpaRepository<TermAgreement, Long> {
+    List<TermAgreement> findByUserId(Long userId);
+}

--- a/api/src/main/java/org/yapp/domain/term/dao/TermRepository.java
+++ b/api/src/main/java/org/yapp/domain/term/dao/TermRepository.java
@@ -1,0 +1,17 @@
+package org.yapp.domain.term.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+import org.yapp.domain.term.Term;
+
+import java.util.List;
+
+@Repository
+public interface TermRepository extends JpaRepository<Term, Long> {
+    @Query("SELECT t.id FROM Term t WHERE t.required = true AND t.isActive = true")
+    List<Long> findRequiredActiveTermIds();
+
+    @Query("SELECT t FROM Term t WHERE t.isActive = true")
+    List<Term> findAllByIsActiveTrue();
+}

--- a/api/src/main/java/org/yapp/domain/term/presentation/TermController.java
+++ b/api/src/main/java/org/yapp/domain/term/presentation/TermController.java
@@ -1,0 +1,31 @@
+package org.yapp.domain.term.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.yapp.domain.term.Term;
+import org.yapp.domain.term.applicatoin.TermService;
+import org.yapp.domain.term.presentation.dto.response.TermResponses;
+import org.yapp.util.CommonResponse;
+
+import java.util.List;
+
+@RequestMapping("/api/terms")
+@Controller
+@RequiredArgsConstructor
+public class TermController {
+    private final TermService termService;
+
+    @GetMapping()
+    @Operation(summary = "약관 리스트 조회", description = "서비스에 등록된 모든 약관을 조회합니다.", tags = {"Term"})
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "약관 리스트가 성공적으로 조회되었습니다.")
+    public ResponseEntity<CommonResponse<TermResponses>> getAllTerms() {
+        List<Term> allActiveTerms = termService.getAllActiveTerms();
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.createSuccess(TermResponses.from(allActiveTerms)));
+    }
+}

--- a/api/src/main/java/org/yapp/domain/term/presentation/dto/response/TermResponse.java
+++ b/api/src/main/java/org/yapp/domain/term/presentation/dto/response/TermResponse.java
@@ -1,0 +1,15 @@
+package org.yapp.domain.term.presentation.dto.response;
+
+import org.yapp.domain.term.Term;
+import java.time.LocalDateTime;
+
+public record TermResponse(
+        Long termId,
+        String title,
+        String content,
+        LocalDateTime startDate
+) {
+    public static TermResponse from(Term term) {
+        return new TermResponse(term.getId(), term.getTitle(), term.getContent(), term.getStartDate());
+    }
+}

--- a/api/src/main/java/org/yapp/domain/term/presentation/dto/response/TermResponses.java
+++ b/api/src/main/java/org/yapp/domain/term/presentation/dto/response/TermResponses.java
@@ -1,0 +1,12 @@
+package org.yapp.domain.term.presentation.dto.response;
+
+import org.yapp.domain.term.Term;
+
+import java.util.List;
+
+public record TermResponses (List<TermResponse> responses) {
+    public static TermResponses from(List<Term> terms) {
+        List<TermResponse> list = terms.stream().map(TermResponse::from).toList();
+        return new TermResponses(list);
+    }
+}

--- a/api/src/main/resources/init.sql
+++ b/api/src/main/resources/init.sql
@@ -26,3 +26,11 @@ VALUES (1, '음주', '연인과 함께 술을 마시는 것을 좋아하나요?'
 INSERT INTO profile_value (profile_value_id, profile_id, value_item_id, selected_answer)
 VALUES (1, 1, 1, 2),
        (2, 1, 2, 3);
+
+INSERT INTO term (version, title, content, required, start_date, is_active)
+VALUES
+    ('1.0', '서비스 이용약관', '서비스 이용에 대한 약관 내용입니다.', true, '2024-01-01 00:00:00', true),
+    ('1.0', '개인정보 처리방침', '개인정보 보호에 대한 약관 내용입니다.', true, '2024-01-01 00:00:00', true),
+    ('1.0', '위치 정보 이용약관', '위치 정보 활용에 대한 약관 내용입니다.', false, '2024-01-01 00:00:00', true),
+    ('1.1', '서비스 이용약관', '서비스 이용약관이 업데이트되었습니다.', true, '2024-06-01 00:00:00', true),
+    ('1.1', '광고 수신 동의', '광고 수신 동의 약관입니다.', false, '2024-06-01 00:00:00', false)

--- a/api/src/test/java/org/yapp/domain/auth/application/term/TermUseCaseTest.java
+++ b/api/src/test/java/org/yapp/domain/auth/application/term/TermUseCaseTest.java
@@ -1,0 +1,117 @@
+//package org.yapp.domain.auth.application.term;
+//
+//
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//import org.mockito.ArgumentCaptor;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.MockitoAnnotations;
+//import org.yapp.domain.profile.Profile;
+//import org.yapp.domain.term.Term;
+//import org.yapp.domain.term.TermAgreement;
+//import org.yapp.domain.term.applicatoin.TermUseCase;
+//import org.yapp.domain.term.applicatoin.dto.SignupTermsDto;
+//import org.yapp.domain.term.dao.TermAgreementRepository;
+//import org.yapp.domain.term.dao.TermRepository;
+//import org.yapp.domain.user.User;
+//import org.yapp.domain.user.application.UserService;
+//import org.yapp.error.exception.ApplicationException;
+//
+//import java.time.LocalDateTime;
+//import java.util.List;
+//import java.util.Optional;
+//
+//import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+//import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+//import static org.mockito.Mockito.verify;
+//import static org.mockito.Mockito.when;
+//
+//public class TermUseCaseTest {
+//
+//    @Mock
+//    private TermRepository termRepository;
+//
+//    @Mock
+//    private TermAgreementRepository termAgreementRepository;
+//
+//    @Mock
+//    private UserService userService;
+//
+//    @InjectMocks
+//    private TermUseCase termUseCase;
+//
+//    @BeforeEach
+//    void setUp() {
+//        MockitoAnnotations.openMocks(this);
+//    }
+//
+//    @Test
+//    void 필수약관_동의_모두_성공() {
+//        // given
+//        SignupTermsDto dto = new SignupTermsDto(1L, List.of(1L, 2L, 3L));
+//        Profile mockProfile = Profile.builder().id(1L).build();
+//        User mockUser = User.builder()
+//                .oauthId("oauth_123")
+//                .name("John Doe")
+//                .profile(mockProfile)
+//                .role("USER")
+//                .build();
+//
+//
+//        when(termRepository.findRequiredActiveTermIds()).thenReturn(List.of(1L, 2L));
+//
+//        when(termAgreementRepository.findByUserId(1L)).thenReturn(List.of());
+//        when(userService.getUserById(1L)).thenReturn(mockUser);
+//        when(termRepository.findById(1L)).thenReturn(Optional.of(new Term(1L, "1.0", "이용약관", "내용", true, LocalDateTime.now(), true)));
+//        when(termRepository.findById(2L)).thenReturn(Optional.of(new Term(2L, "1.0", "개인정보처리방침", "내용", true, LocalDateTime.now(), true)));
+//
+//        // when
+//        termUseCase.checkTermConstraints(dto);
+//
+//        // then
+//        ArgumentCaptor<List<TermAgreement>> captor = ArgumentCaptor.forClass(List.class);
+//        verify(termAgreementRepository).saveAll(captor.capture());
+//
+//        List<TermAgreement> savedAgreements = captor.getValue();
+//        assertThat(savedAgreements).hasSize(2);
+//        assertThat(savedAgreements.get(0).getUser().getId()).isEqualTo(1L);
+//        assertThat(savedAgreements.get(1).getTerm().getId()).isEqualTo(2L);
+//    }
+//
+//    @Test
+//    void 필수약관_미동의시_예외발생() {
+//        // given
+//        SignupTermsDto dto = new SignupTermsDto(1L, List.of(1L));  // 1번 약관만 동의
+//        when(termRepository.findRequiredActiveTermIds()).thenReturn(List.of(1L, 2L));  // 1, 2번 필수 약관 필요
+//
+//        // when & then
+//        assertThatThrownBy(() -> termUseCase.checkTermConstraints(dto))
+//                .isInstanceOf(IllegalStateException.class)
+//                .hasMessageContaining("모든 필수 약관에 동의해야 회원가입이 가능합니다.");
+//    }
+//
+//    @Test
+//    void 존재하지_않는_약관에_동의시_예외발생() {
+//        // given
+//        SignupTermsDto dto = new SignupTermsDto(1L, List.of(1L, 2L));
+//        Profile mockProfile = Profile.builder().id(1L).build();
+//        User mockUser = User.builder()
+//                .oauthId("oauth_123")
+//                .name("John Doe")
+//                .profile(mockProfile)
+//                .role("USER")
+//                .build();
+//
+//        when(termRepository.findRequiredActiveTermIds()).thenReturn(List.of(1L, 2L));
+//        when(termAgreementRepository.findByUserId(1L)).thenReturn(List.of());
+//        when(userService.getUserById(1L)).thenReturn(mockUser);
+//        when(termRepository.findById(1L)).thenReturn(Optional.of(new Term(1L, "1.0", "이용약관", "내용", true, LocalDateTime.now(), true)));
+//        when(termRepository.findById(2L)).thenReturn(Optional.empty());  // 2번 약관은 없음
+//
+//        // when & then
+//        assertThatThrownBy(() -> termUseCase.checkTermConstraints(dto))
+//                .isInstanceOf(ApplicationException.class)
+//                .hasMessageContaining("유효하지 않은 약관입니다.");
+//    }
+//}

--- a/common/src/main/java/org/yapp/domain/term/Term.java
+++ b/common/src/main/java/org/yapp/domain/term/Term.java
@@ -1,0 +1,38 @@
+package org.yapp.domain.term;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Term {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "term_id")
+    private long id;
+
+    private String version;
+
+    private String title;
+
+    private String content;
+
+    private boolean required;
+
+    @Column(nullable = false)
+
+    private LocalDateTime startDate;
+    @Column(nullable = false)
+
+    @ColumnDefault(value = "true")
+    private boolean isActive;
+}

--- a/common/src/main/java/org/yapp/domain/term/TermAgreement.java
+++ b/common/src/main/java/org/yapp/domain/term/TermAgreement.java
@@ -1,0 +1,33 @@
+package org.yapp.domain.term;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.yapp.domain.user.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TermAgreement {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "agreement_id")
+    private long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "term_id", nullable = false)
+    private Term term;
+
+    @Column(nullable = false)
+    private LocalDateTime agreedAt;
+}

--- a/common/src/main/java/org/yapp/error/dto/TermErrorCode.java
+++ b/common/src/main/java/org/yapp/error/dto/TermErrorCode.java
@@ -1,0 +1,16 @@
+package org.yapp.error.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TermErrorCode implements ErrorCode {
+    INACTIVE_TERM(HttpStatus.FORBIDDEN, "접근이 금지된 약관입니다."),
+    NOTFOUND_TERM(HttpStatus.NOT_FOUND, "유효하지 않은 약관입니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-197](https://yapp25app3.atlassian.net/browse/PC-197)
## ✨ 작업 내용
- 서비스 등록 약관 조회 기능
- 회원가입시 약관 등록 기능

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] Label을 지정했나요?
  
- [x] merge할 브랜치의 위치를 확인했나요?
## 🎃 새롭게 알게된 사항

## 📋 참고 사항
- 코드 리뷰 시 논의가 필요한 사항이나 배포 관련 주의 사항을 추가합니다.

서비스 등록 약관 조회 기능은 더미 데이터를 활용해서 API를 테스트해봤는데, 회원가입시 사용자 약관을 등록하는 로직은 실제로 클라이언트와 연동하면서 테스트하는 것이 나을 것 같습니다. 


[PC-197]: https://yapp25app3.atlassian.net/browse/PC-197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ