### PR TITLE
[PC-214] 회원가입 절차에 SMS 인증번호 검증 로직 추가

### DIFF
--- a/api/src/main/java/org/yapp/domain/auth/application/authorization/SmsAuthService.java
+++ b/api/src/main/java/org/yapp/domain/auth/application/authorization/SmsAuthService.java
@@ -1,6 +1,9 @@
 package org.yapp.domain.auth.application.authorization;
 
 import org.springframework.stereotype.Service;
+import org.yapp.error.code.auth.SmsAuthErrorCode;
+import org.yapp.error.exception.ApplicationException;
+import org.yapp.global.application.RedisService;
 import org.yapp.global.application.SmsSenderService;
 
 import lombok.RequiredArgsConstructor;
@@ -12,8 +15,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SmsAuthService {
   private static final String AUTH_CODE_FORMAT = "[PIECE] 인증 번호는 %d 입니다.";
+  private static final long AUTH_CODE_EXPIRE_TIME = 300000;
+  private static final String AUTH_CODE_KEY_PREFIX = "authcode:";
   private final AuthCodeGenerator authCodeGenerator;
   private final SmsSenderService smsSenderService;
+  private final RedisService redisService;
 
   /**
    * 인증번호 전송
@@ -22,7 +28,26 @@ public class SmsAuthService {
    */
   public void sendAuthCodeTo(String phoneNumber) {
     int authCode = authCodeGenerator.generate();
+    redisService.setKeyWithExpiration(AUTH_CODE_KEY_PREFIX + phoneNumber, String.valueOf(authCode),
+        AUTH_CODE_EXPIRE_TIME);
     String authCodeMessage = String.format(AUTH_CODE_FORMAT, authCode);
     smsSenderService.sendSMS(phoneNumber, authCodeMessage);
+  }
+
+  /**
+   * 인증번호 인증
+   *
+   * @param phoneNumber 핸드폰번호
+   * @param code        인증 번호
+   * @return 인증번호 일치 여부
+   */
+  public void verifySmsAuthCode(String phoneNumber, String code) {
+    String expectedCode = redisService.getValue(AUTH_CODE_KEY_PREFIX + phoneNumber);
+    if (expectedCode == null) {
+      throw new ApplicationException(SmsAuthErrorCode.CODE_NOT_EXIST);
+    }
+    if (!expectedCode.equals(code)) {
+      throw new ApplicationException(SmsAuthErrorCode.CODE_NOT_CORRECT);
+    }
   }
 }

--- a/api/src/main/java/org/yapp/domain/auth/application/oauth/service/OauthService.java
+++ b/api/src/main/java/org/yapp/domain/auth/application/oauth/service/OauthService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import org.yapp.domain.auth.application.jwt.JwtUtil;
 import org.yapp.domain.auth.application.oauth.OauthProvider;
 import org.yapp.domain.auth.application.oauth.OauthProviderResolver;
+import org.yapp.domain.auth.presentation.dto.enums.RoleStatus;
 import org.yapp.domain.auth.presentation.dto.request.OauthLoginRequest;
 import org.yapp.domain.auth.presentation.dto.response.OauthLoginResponse;
 import org.yapp.domain.user.User;
@@ -27,21 +28,33 @@ public class OauthService {
     //이미 가입된 유저인지 확인하고 가입되어 있지 않으면 회원가입 처리
     Optional<User> userOptional = userRepository.findByOauthId(oauthId);
     if (userOptional.isEmpty()) {
-      User newUser = User.builder().oauthId(oauthId).build();
+      User newUser = User.builder().oauthId(oauthId).role(RoleStatus.NONE.getStatus()).build();
       User savedUser = userRepository.save(newUser);
       Long userId = savedUser.getId();
-      String accessToken = jwtUtil.createJwt("access_token", userId, oauthId, "USER", 600000L);
-      String refreshToken = jwtUtil.createJwt("refresh_token", userId, oauthId, "USER", 864000000L);
-      return new OauthLoginResponse(true, accessToken, refreshToken);
+      String accessToken = jwtUtil.createJwt("access_token", userId, oauthId, "NONE", 600000L);
+      String refreshToken = jwtUtil.createJwt("refresh_token", userId, oauthId, "NONE", 864000000L);
+      return new OauthLoginResponse(RoleStatus.NONE.getStatus(), accessToken, refreshToken);
     }
 
     //이미 가입한 유저인 경우 로그인 처리
     Long userId = userOptional.get().getId();
     final User user = userOptional.get();
+
     String accessToken = jwtUtil.createJwt("access_token", userId, oauthId, user.getRole(), 600000L);
     String refreshToken = jwtUtil.createJwt("refresh_token", userId, oauthId, user.getRole(), 864000000L);
 
-    return new OauthLoginResponse(false, accessToken, refreshToken);
+    //아직 SMS 인증이 완료되지 않음
+    if (user.getRole().equals("NONE")) {
+      return new OauthLoginResponse(RoleStatus.NONE.getStatus(), accessToken, refreshToken);
+    }
+
+    // SMS 인증은 완료되었으나, 프로필 등록을 안함
+    if (user.getRole().equals("REGISTER")) {
+      return new OauthLoginResponse(RoleStatus.REGISTER.getStatus(), accessToken, refreshToken);
+    }
+
+    // 가입과 프로필 등록까지 완료된 유저
+    return new OauthLoginResponse(user.getRole(), accessToken, refreshToken);
   }
 
 
@@ -56,6 +69,6 @@ public class OauthService {
     String accessToken = jwtUtil.createJwt("access_token", userId, user.getOauthId(), user.getRole(), 600000L);
     String refreshToken = jwtUtil.createJwt("refresh_token", userId, user.getOauthId(), user.getRole(), 864000000L);
 
-    return new OauthLoginResponse(false, accessToken, refreshToken);
+    return new OauthLoginResponse(RoleStatus.NONE.getStatus(), accessToken, refreshToken);
   }
 }

--- a/api/src/main/java/org/yapp/domain/auth/presentation/LoginController.java
+++ b/api/src/main/java/org/yapp/domain/auth/presentation/LoginController.java
@@ -14,7 +14,7 @@ import org.yapp.util.CommonResponse;
 import lombok.RequiredArgsConstructor;
 
 @Controller
-@RequestMapping("/login")
+@RequestMapping("/api/login")
 @RequiredArgsConstructor
 public class LoginController {
   private final OauthService oauthService;

--- a/api/src/main/java/org/yapp/domain/auth/presentation/SmsAuthController.java
+++ b/api/src/main/java/org/yapp/domain/auth/presentation/SmsAuthController.java
@@ -1,0 +1,36 @@
+package org.yapp.domain.auth.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.yapp.domain.auth.application.authorization.SmsAuthService;
+import org.yapp.domain.auth.presentation.dto.request.SmsAuthRequest;
+import org.yapp.domain.auth.presentation.dto.request.SmsAuthVerifyRequest;
+import org.yapp.domain.auth.presentation.dto.response.OauthLoginResponse;
+import org.yapp.domain.user.application.UserService;
+import org.yapp.util.CommonResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/register/sms/auth")
+public class SmsAuthController {
+  private final SmsAuthService smsAuthService;
+  private final UserService userService;
+
+  @PostMapping("/code")
+  public ResponseEntity<CommonResponse> sendSms(@RequestBody SmsAuthRequest smsAuthRequest) {
+    smsAuthService.sendAuthCodeTo(smsAuthRequest.getPhoneNumber());
+    return ResponseEntity.ok(CommonResponse.createSuccessWithNoContent());
+  }
+
+  @PostMapping("/code/verify")
+  public ResponseEntity<CommonResponse> verifyCode(@RequestBody SmsAuthVerifyRequest request) {
+    smsAuthService.verifySmsAuthCode(request.getPhoneNumber(), request.getCode());
+    OauthLoginResponse registerToken = userService.registerPhoneNumber(request.getPhoneNumber());
+    return ResponseEntity.ok(CommonResponse.createSuccess(registerToken));
+  }
+}

--- a/api/src/main/java/org/yapp/domain/auth/presentation/dto/enums/RoleStatus.java
+++ b/api/src/main/java/org/yapp/domain/auth/presentation/dto/enums/RoleStatus.java
@@ -1,0 +1,18 @@
+package org.yapp.domain.auth.presentation.dto.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum RoleStatus {
+  NONE("NONE"),
+  REGISTER("REGISTER"),
+  USER("USER");
+  private String status;
+
+  @JsonValue
+  public String getStatus() {
+    return status;
+  }
+}

--- a/api/src/main/java/org/yapp/domain/auth/presentation/dto/request/SmsAuthRequest.java
+++ b/api/src/main/java/org/yapp/domain/auth/presentation/dto/request/SmsAuthRequest.java
@@ -1,0 +1,10 @@
+package org.yapp.domain.auth.presentation.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class SmsAuthRequest {
+  private String phoneNumber;
+}

--- a/api/src/main/java/org/yapp/domain/auth/presentation/dto/request/SmsAuthVerifyRequest.java
+++ b/api/src/main/java/org/yapp/domain/auth/presentation/dto/request/SmsAuthVerifyRequest.java
@@ -1,0 +1,11 @@
+package org.yapp.domain.auth.presentation.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class SmsAuthVerifyRequest {
+  private String phoneNumber;
+  private String code;
+}

--- a/api/src/main/java/org/yapp/domain/auth/presentation/dto/response/OauthLoginResponse.java
+++ b/api/src/main/java/org/yapp/domain/auth/presentation/dto/response/OauthLoginResponse.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 public class OauthLoginResponse {
-  private boolean registered;
+  private String role;
   private String accessToken;
   private String refreshToken;
 }

--- a/api/src/main/java/org/yapp/domain/user/application/UserService.java
+++ b/api/src/main/java/org/yapp/domain/user/application/UserService.java
@@ -1,6 +1,12 @@
 package org.yapp.domain.user.application;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.yapp.application.AuthenticationService;
+import org.yapp.domain.auth.application.jwt.JwtUtil;
+import org.yapp.domain.auth.presentation.dto.enums.RoleStatus;
+import org.yapp.domain.auth.presentation.dto.response.OauthLoginResponse;
+import org.yapp.domain.profile.Profile;
 import org.yapp.domain.user.User;
 import org.yapp.domain.user.dao.UserRepository;
 import org.yapp.error.dto.UserErrorCode;
@@ -12,8 +18,46 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserService {
   private final UserRepository userRepository;
+  private final AuthenticationService authenticationService;
+  private final JwtUtil jwtUtil;
+
+  /**
+   * Role을 USER로 바꾸고 변경된 토큰을 반환한다.
+   *
+   * @return 액세스토큰과 리프레시 토큰
+   */
+  @Transactional
+  public OauthLoginResponse completeProfileInitialize(Profile profile) {
+    Long userId = authenticationService.getUserId();
+    User user =
+        userRepository.findById(userId).orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
+    user.setProfile(profile);
+    user.updateUserRole(RoleStatus.USER.getStatus());
+    String oauthId = user.getOauthId();
+    String accessToken = jwtUtil.createJwt("access_token", userId, oauthId, user.getRole(), 600000L);
+    String refreshToken = jwtUtil.createJwt("refresh_token", userId, oauthId, user.getRole(), 864000000L);
+    return new OauthLoginResponse(RoleStatus.USER.getStatus(), accessToken, refreshToken);
+  }
 
   public User getUserById(Long userId) {
     return userRepository.findById(userId).orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
+  }
+
+  /**
+   * Role을 Register로 바꾸고 변경된 토큰을 반환한다.
+   *
+   * @return 액세스토큰과 리프레시 토큰
+   */
+  @Transactional
+  public OauthLoginResponse registerPhoneNumber(String phoneNumber) {
+    Long userId = authenticationService.getUserId();
+    User user =
+        userRepository.findById(userId).orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
+    user.updateUserRole(RoleStatus.REGISTER.getStatus());
+    user.initializePhoneNumber(phoneNumber);
+    String oauthId = user.getOauthId();
+    String accessToken = jwtUtil.createJwt("access_token", userId, oauthId, user.getRole(), 600000L);
+    String refreshToken = jwtUtil.createJwt("refresh_token", userId, oauthId, user.getRole(), 864000000L);
+    return new OauthLoginResponse(RoleStatus.REGISTER.getStatus(), accessToken, refreshToken);
   }
 }

--- a/api/src/main/java/org/yapp/global/application/RedisService.java
+++ b/api/src/main/java/org/yapp/global/application/RedisService.java
@@ -1,0 +1,27 @@
+package org.yapp.global.application;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+  private final StringRedisTemplate redisTemplate;
+
+  public void deleteKey(String key) {
+    redisTemplate.delete(key);
+  }
+
+  public String getValue(String key) {
+    return redisTemplate.opsForValue().get(key);
+  }
+
+  public void setKeyWithExpiration(String key, String value, long expiredTime) {
+    redisTemplate.opsForValue().set(key, value, Duration.ofMillis(expiredTime));
+  }
+}

--- a/api/src/main/java/org/yapp/global/config/SecurityConfig.java
+++ b/api/src/main/java/org/yapp/global/config/SecurityConfig.java
@@ -54,8 +54,12 @@ public class SecurityConfig {
   }
 
   private RequestMatcher getMatcherForAnyone() {
-    return RequestMatchers.anyOf(antMatcher("/login/**"), antMatcher("/api/**"), antMatcher("/swagger-ui/**"),
+    return RequestMatchers.anyOf(antMatcher("/api/login/**"), antMatcher("/api/**"), antMatcher("/swagger-ui/**"),
         antMatcher("/v3/api-docs/**"), antMatcher("/swagger-ui.html"));
+  }
+
+  private RequestMatcher getMatcherForRegister() {
+    return RequestMatchers.anyOf(antMatcher("/api/profiles/init"));
   }
 
   private RequestMatcher getMatcherForUserAndAdmin() {

--- a/api/src/test/java/org/yapp/domain/auth/application/authorization/SmsAuthServiceTest.java
+++ b/api/src/test/java/org/yapp/domain/auth/application/authorization/SmsAuthServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.yapp.global.application.RedisService;
 import org.yapp.global.application.SmsSenderService;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,9 +25,12 @@ class SmsAuthServiceTest {
   @Mock
   private SmsSenderService smsSenderService;
 
+  @Mock
+  private RedisService redisService;
+
   @BeforeEach
   void setUp() {
-    smsAuthService = new SmsAuthService(authCodeGenerator, smsSenderService);
+    smsAuthService = new SmsAuthService(authCodeGenerator, smsSenderService, redisService);
   }
 
   @Test

--- a/api/src/test/java/org/yapp/domain/auth/application/oauth/service/OauthServiceTest.java
+++ b/api/src/test/java/org/yapp/domain/auth/application/oauth/service/OauthServiceTest.java
@@ -57,7 +57,6 @@ class OauthServiceTest {
     OauthLoginResponse response = oauthService.login(request);
 
     // Then
-    assertThat(response.isRegistered()).isTrue();
     assertThat(response.getAccessToken()).isEqualTo("access_token");
     assertThat(response.getRefreshToken()).isEqualTo("refresh_token");
   }
@@ -98,7 +97,6 @@ class OauthServiceTest {
     OauthLoginResponse response = oauthService.login(request);
 
     // Then
-    assertThat(response.isRegistered()).isFalse();
     assertThat(response.getAccessToken()).isEqualTo("access_token");
     assertThat(response.getRefreshToken()).isEqualTo("refresh_token");
   }

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,9 @@ subprojects {
         //cool sms
         implementation 'net.nurigo:sdk:4.3.0'
 
+        //redis
+        implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
         compileOnly 'org.projectlombok:lombok'
         runtimeOnly 'com.mysql:mysql-connector-j'
         annotationProcessor 'org.projectlombok:lombok'

--- a/common/src/main/java/org/yapp/application/AuthenticationService.java
+++ b/common/src/main/java/org/yapp/application/AuthenticationService.java
@@ -1,0 +1,16 @@
+package org.yapp.application;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthenticationService {
+  public Authentication getAuthentication() {
+    return SecurityContextHolder.getContext().getAuthentication();
+  }
+
+  public Long getUserId() {
+    return (Long) getAuthentication().getPrincipal();
+  }
+}

--- a/common/src/main/java/org/yapp/config/RedisConfig.java
+++ b/common/src/main/java/org/yapp/config/RedisConfig.java
@@ -1,0 +1,20 @@
+package org.yapp.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+  @Value("${redis.host}")
+  private String host;
+  @Value("${redis.port}")
+  private int port;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(host, port);
+  }
+}

--- a/common/src/main/java/org/yapp/domain/user/User.java
+++ b/common/src/main/java/org/yapp/domain/user/User.java
@@ -30,6 +30,9 @@ public class User {
   @Column(name = "name")
   private String name;
 
+  @Column(name = "phone")
+  private String phoneNumber;
+
   @Column(name = "role")
   private String role = "USER";
 
@@ -45,8 +48,16 @@ public class User {
     this.role = role;
   }
 
+  public void initializePhoneNumber(String phoneNumber) {
+    this.phoneNumber = phoneNumber;
+  }
+
   public void setProfile(Profile profile) {
     this.profile = profile;
+  }
+
+  public void updateUserRole(String role) {
+    this.role = role;
   }
 }
 

--- a/common/src/main/java/org/yapp/error/code/auth/SmsAuthErrorCode.java
+++ b/common/src/main/java/org/yapp/error/code/auth/SmsAuthErrorCode.java
@@ -1,0 +1,16 @@
+package org.yapp.error.code.auth;
+
+import org.springframework.http.HttpStatus;
+import org.yapp.error.dto.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SmsAuthErrorCode implements ErrorCode {
+  CODE_NOT_EXIST(HttpStatus.BAD_REQUEST, "code not exist"),
+  CODE_NOT_CORRECT(HttpStatus.BAD_REQUEST, "code not correct");
+  private final HttpStatus httpStatus;
+  private final String message;
+}


### PR DESCRIPTION
## 🔗 관련 이슈

## ✨ 작업 내용
- 인증번호 검증 로직 추가
- redis를 통해 인증번호에 TTL 설정 - 5분
- Role 기반 인증 단계 인식 기능 추가
- RedisService 추가
- sms 인증/검증 엔드포인트 추가
- 프로필 초기화 기능 추가

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항

## 📋 참고 사항
- 프로필 생성 로직을 논의해서 수정할 필요가 있을 것 같습니다
    - 닉네임 자동생성 중복 검사 로직