### PR TITLE
[PC-379] 어드민 모듈 로그인 기능

### DIFF
--- a/admin/build.gradle
+++ b/admin/build.gradle
@@ -13,7 +13,8 @@ dependencies {
     implementation project(':common:domain')
     implementation project(':common:format')
     implementation project(':common:exception')
-    
+    implementation project(':common:auth')
+
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/admin/src/main/java/org/yapp/auth/application/AdminRole.java
+++ b/admin/src/main/java/org/yapp/auth/application/AdminRole.java
@@ -1,0 +1,6 @@
+package org.yapp.auth.application;
+
+public enum AdminRole {
+    ADMIN,
+    ROLE_ADMIN;
+}

--- a/admin/src/main/java/org/yapp/auth/application/AuthService.java
+++ b/admin/src/main/java/org/yapp/auth/application/AuthService.java
@@ -1,0 +1,40 @@
+package org.yapp.auth.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.yapp.auth.AuthToken;
+import org.yapp.auth.AuthTokenGenerator;
+import org.yapp.auth.application.dto.LoginDto;
+import org.yapp.domain.user.User;
+import org.yapp.error.code.auth.AuthErrorCode;
+import org.yapp.error.exception.ApplicationException;
+import org.yapp.user.application.UserService;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserService userService;
+
+    private final AuthTokenGenerator authTokenGenerator;
+
+    @Value("${admin.password}")
+    private String PWD;
+
+    public AuthToken login(LoginDto loginDto) {
+        String oauthId = loginDto.oauthId();
+        String password = loginDto.password();
+
+        User loginUser = userService.getUserByOauthId(oauthId);
+
+        if (password.equals(PWD) && loginUser.getRole().equals(AdminRole.ADMIN.toString())) {
+            return authTokenGenerator.generate(loginUser.getId(), null,
+                AdminRole.ROLE_ADMIN.toString());
+        } else {
+            throw new ApplicationException(AuthErrorCode.ACCESS_DENIED);
+        }
+    }
+}

--- a/admin/src/main/java/org/yapp/auth/application/dto/LoginDto.java
+++ b/admin/src/main/java/org/yapp/auth/application/dto/LoginDto.java
@@ -1,0 +1,5 @@
+package org.yapp.auth.application.dto;
+
+public record LoginDto(String oauthId, String password) {
+
+}

--- a/admin/src/main/java/org/yapp/auth/presentation/AuthController.java
+++ b/admin/src/main/java/org/yapp/auth/presentation/AuthController.java
@@ -1,0 +1,28 @@
+package org.yapp.auth.presentation;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.yapp.auth.AuthToken;
+import org.yapp.auth.application.AuthService;
+import org.yapp.auth.presentation.request.LoginRequest;
+import org.yapp.util.CommonResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/v1/auth/")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<CommonResponse<AuthToken>> login(
+        @RequestBody @Valid LoginRequest loginRequest) {
+        AuthToken authToken = authService.login(loginRequest.toDto());
+        return ResponseEntity.ok(CommonResponse.createSuccess(authToken));
+    }
+}

--- a/admin/src/main/java/org/yapp/auth/presentation/request/LoginRequest.java
+++ b/admin/src/main/java/org/yapp/auth/presentation/request/LoginRequest.java
@@ -1,0 +1,11 @@
+package org.yapp.auth.presentation.request;
+
+import jakarta.validation.constraints.NotNull;
+import org.yapp.auth.application.dto.LoginDto;
+
+public record LoginRequest(@NotNull String loginId, @NotNull String password) {
+
+    public LoginDto toDto() {
+        return new LoginDto(loginId, password);
+    }
+}

--- a/admin/src/main/java/org/yapp/config/SecurityConfig.java
+++ b/admin/src/main/java/org/yapp/config/SecurityConfig.java
@@ -11,15 +11,19 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatchers;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
+import org.yapp.jwt.JwtFilter;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtFilter jwtFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -33,6 +37,7 @@ public class SecurityConfig {
                 .permitAll()
                 .anyRequest()
                 .hasAnyRole("ADMIN"))
+            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
             .build();
     }
 
@@ -47,6 +52,6 @@ public class SecurityConfig {
     }
 
     private RequestMatcher getMatcherForAnyone() {
-        return RequestMatchers.anyOf(antMatcher("/admin/v1/login/**"));
+        return RequestMatchers.anyOf(antMatcher("/admin/v1/auth/login/**"));
     }
 }

--- a/admin/src/main/java/org/yapp/user/application/UserService.java
+++ b/admin/src/main/java/org/yapp/user/application/UserService.java
@@ -36,6 +36,11 @@ public class UserService {
             .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
     }
 
+    public User getUserByOauthId(String oauthId) {
+        return userRepository.findByOauthId(oauthId)
+            .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
+    }
+
     public PageResponse<UserProfileValidationResponse> getUserProfilesWithPagination(int page,
         int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));

--- a/admin/src/main/java/org/yapp/user/dao/UserRepository.java
+++ b/admin/src/main/java/org/yapp/user/dao/UserRepository.java
@@ -9,4 +9,6 @@ import org.yapp.domain.user.User;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findById(Long userId);
+
+    Optional<User> findByOauthId(String oauthId);
 }

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    include: db
+    include: db, secret

--- a/common/auth/build.gradle
+++ b/common/auth/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'java'
+}
+
+group = 'org.yapp'
+version = '0.0.1-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation platform('org.junit:junit-bom:5.10.0')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/common/auth/src/main/java/org/yapp/auth/AuthToken.java
+++ b/common/auth/src/main/java/org/yapp/auth/AuthToken.java
@@ -1,0 +1,5 @@
+package org.yapp.auth;
+
+public record AuthToken(String accessToken, String refreshToken) {
+
+}

--- a/common/auth/src/main/java/org/yapp/auth/AuthTokenGenerator.java
+++ b/common/auth/src/main/java/org/yapp/auth/AuthTokenGenerator.java
@@ -1,0 +1,30 @@
+package org.yapp.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.yapp.jwt.JwtUtil;
+
+@Component
+@RequiredArgsConstructor
+public class AuthTokenGenerator {
+
+    private final JwtUtil jwtUtil;
+
+    @Value("${jwt.accessToken.expiration}")
+    private Long accessTokenExpiration;
+
+    @Value("${jwt.refreshToken.expiration}")
+    private Long refreshTokenExpiration;
+
+
+    public AuthToken generate(Long userId, String oauthId, String role) {
+        String accessToken = jwtUtil.createJwt("access_token", userId, oauthId, role,
+            accessTokenExpiration);
+
+        String refreshToken = jwtUtil.createJwt("refesh_token", userId, oauthId, role,
+            refreshTokenExpiration);
+
+        return new AuthToken(accessToken, refreshToken);
+    }
+}

--- a/common/auth/src/main/java/org/yapp/jwt/JwtFilter.java
+++ b/common/auth/src/main/java/org/yapp/jwt/JwtFilter.java
@@ -1,0 +1,68 @@
+package org.yapp.jwt;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+@Component
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain)
+        throws ServletException, IOException {
+
+        String accessToken = request.getHeader("Authorization");
+        if (accessToken == null || !accessToken.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        accessToken = accessToken.substring(7);
+
+        try {
+            jwtUtil.isExpired(accessToken);
+        } catch (ExpiredJwtException e) {
+
+            PrintWriter writer = response.getWriter();
+            writer.print("access token expired");
+
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        String category = jwtUtil.getCategory(accessToken);
+        if (!category.equals("access_token")) {
+            PrintWriter writer = response.getWriter();
+            writer.print("invalid access token");
+
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        Long userId = jwtUtil.getUserId(accessToken);
+        String role = jwtUtil.getRole(accessToken);
+
+        Authentication authToken =
+            new UsernamePasswordAuthenticationToken(userId, null, Collections.singleton(
+                (GrantedAuthority) () -> role));
+
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/common/auth/src/main/java/org/yapp/jwt/JwtUtil.java
+++ b/common/auth/src/main/java/org/yapp/jwt/JwtUtil.java
@@ -1,0 +1,89 @@
+package org.yapp.jwt;
+
+import io.jsonwebtoken.Jwts;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+
+    public JwtUtil(@Value("${jwt.secret}") String secret) {
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8),
+            Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public String getOauthId(String token) {
+        String oauthId;
+        try {
+            oauthId = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token)
+                .getPayload().get("oauthId", String.class);
+        } catch (Exception e) {
+            throw new RuntimeException();
+        }
+        return oauthId;
+    }
+
+    public String getRole(String token) {
+        String role;
+        try {
+            role = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+                .get("role", String.class);
+        } catch (Exception e) {
+            throw new RuntimeException();
+        }
+        return role;
+    }
+
+    public Boolean isExpired(String token) {
+        boolean before;
+        try {
+            before = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token)
+                .getPayload().getExpiration().before(new Date());
+        } catch (Exception e) {
+            throw new RuntimeException();
+        }
+        return before;
+    }
+
+    public String createJwt(String category, Long userId, String oauthId, String role,
+        Long expiredMs) {
+        return Jwts.builder()
+            .claim("category", category)
+            .claim("userId", userId)
+            .claim("oauthId", oauthId)
+            .claim("role", role)
+            .issuedAt(new Date(System.currentTimeMillis()))
+            .expiration(new Date(System.currentTimeMillis() + expiredMs))
+            .signWith(secretKey)
+            .compact();
+    }
+
+    public Long getUserId(String token) {
+        Long userId;
+        try {
+            userId = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token)
+                .getPayload().get("userId", Long.class);
+        } catch (Exception e) {
+            throw new RuntimeException();
+        }
+        return userId;
+    }
+
+    public String getCategory(String token) {
+        String category;
+        try {
+            category = Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token)
+                .getPayload().get("category", String.class);
+        } catch (Exception e) {
+            throw new RuntimeException();
+        }
+        return category;
+    }
+}
+

--- a/common/exception/src/main/java/org/yapp/error/code/auth/AuthErrorCode.java
+++ b/common/exception/src/main/java/org/yapp/error/code/auth/AuthErrorCode.java
@@ -9,7 +9,9 @@ import org.yapp.error.dto.ErrorCode;
 @RequiredArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
     OAUTH_ERROR(HttpStatus.FORBIDDEN, "Oauth Error"),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "권한이 없습니다."),
     ;
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,4 +8,6 @@ include 'common:exception'
 findProject(':common:exception')?.name = 'exception'
 include 'common:format'
 findProject(':common:format')?.name = 'format'
+include 'common:auth'
+findProject(':common:auth')?.name = 'auth'
 


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-379](https://yapp25app3.atlassian.net/browse/PC-379)

## ✨ 작업 내용
- api 모듈에 있던 jwt 기능을 common:auth 모듈로 리팩토링
- common:auth에 Token 생성 기능 추가
- admin 모듈 로그인 기능

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항

## 📋 참고 사항
- 코드 리뷰 시 논의가 필요한 사항이나 배포 관련 주의 사항을 추가합니다.
로그인하는 사용자를 위해 common:auth 모듈을 만들고 admin 모듈에서는 common:auth를 사용하도록 하였습니다.
토큰을 생성하는 로직을 api 모듈에서도 common:auth 기능을 사용하도록 수정해야합니다.


[PC-379]: https://yapp25app3.atlassian.net/browse/PC-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ