### PR TITLE
[PC-478] SSE Flux 구현

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -14,6 +14,8 @@ dependencies {
     implementation project(':core:format')
     implementation project(':core:exception')
     implementation project(':core:auth')
+    implementation project(':core:sse')
+
     implementation project(':infra:s3')
     implementation project(':infra:redis')
     implementation project(':infra:sms')

--- a/api/src/main/java/org/yapp/domain/profile/application/ProfileImageService.java
+++ b/api/src/main/java/org/yapp/domain/profile/application/ProfileImageService.java
@@ -1,21 +1,33 @@
 package org.yapp.domain.profile.application;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import org.yapp.core.exception.ApplicationException;
+import org.yapp.core.exception.error.code.ProfileErrorCode;
 import org.yapp.infra.s3.application.S3Service;
-
-import java.io.IOException;
-import java.util.UUID;
-
-import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class ProfileImageService {
+
     private final S3Service s3Service;
+    private static final List<String> ALLOWED_MIME_TYPES = List.of("image/jpeg",
+        "image/png", "image/webp");
 
     public String uploadProfileImage(MultipartFile file) throws IOException {
-        String uniqueFileName = "profiles/image/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+        String uniqueFileName =
+            "profiles/image/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+
+        String contentType = file.getContentType();
+
+        if (contentType == null || !ALLOWED_MIME_TYPES.contains(contentType)) {
+            throw new ApplicationException(ProfileErrorCode.INVALID_PROFILE_IMAGE_TYPE);
+        }
+
         return s3Service.upload(file, uniqueFileName);
     }
 }

--- a/api/src/main/java/org/yapp/domain/profile/presentation/ProfileController.java
+++ b/api/src/main/java/org/yapp/domain/profile/presentation/ProfileController.java
@@ -1,12 +1,14 @@
 package org.yapp.domain.profile.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -148,10 +150,11 @@ public class ProfileController {
         return ResponseEntity.status(HttpStatus.OK).body(CommonResponse.createSuccess(isAvailable));
     }
 
-    @PostMapping("/images")
-    @Operation(summary = "프로필 이미지 등록", description = "업로드한 이미지지를 버킷에 등록합니다.", tags = {"프로필 이미지"})
+    @PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "프로필 이미지 등록", description = "업로드한 이미지를 버킷에 등록합니다.", tags = {"프로필 이미지"})
     @ApiResponse(responseCode = "200", description = "이미지가 버킷에 저장되었습니다.")
     public ResponseEntity<CommonResponse<String>> uploadProfileImage(
+        @Parameter(description = "업로드할 프로필 이미지 파일 form-data 바이너리 파일 (JPEG, PNG, WEBP 지원)", required = true)
         @RequestParam("file") MultipartFile file) throws IOException {
         String profileImageUrl = profileImageService.uploadProfileImage(file);
         return ResponseEntity.status(HttpStatus.OK)

--- a/api/src/main/java/org/yapp/global/config/SecurityConfig.java
+++ b/api/src/main/java/org/yapp/global/config/SecurityConfig.java
@@ -32,12 +32,13 @@ public class SecurityConfig {
             .httpBasic(AbstractHttpConfigurer::disable)
             .sessionManagement(
                 configurer -> configurer.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-            .authorizeHttpRequests(registry -> registry.requestMatchers(getMatcherForUserAndAdmin())
+            .authorizeHttpRequests(registry -> registry
+                .requestMatchers(getMatcherForUserAndAdmin())
                 .hasAnyRole("USER", "ADMIN")
                 .requestMatchers(getMatcherForAnyone())
                 .permitAll()
                 .anyRequest()
-                .hasAnyRole("ADMIN"))
+                .authenticated())
             .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
             .build();
     }

--- a/api/src/main/java/org/yapp/sse/presentation/SseController.java
+++ b/api/src/main/java/org/yapp/sse/presentation/SseController.java
@@ -20,7 +20,7 @@ public class SseController {
 
     @PreAuthorize(value = "hasRole('USER')")
     @GetMapping("/personal")
-    @Operation(summary = "SSE 연결", description = "로그인한 회원에대한 event 수신 stream을 얻습니다", tags = {"SSE"})
+    @Operation(summary = "SSE 연결", description = "로그인 회원에대한 event 수신 stream을 얻습니다", tags = {"SSE"})
     public Flux<ServerSentEvent<Object>> streamEvents(@AuthenticationPrincipal Long userId) {
         return ssePersonalService.connect(userId);
     }

--- a/api/src/main/java/org/yapp/sse/presentation/SseController.java
+++ b/api/src/main/java/org/yapp/sse/presentation/SseController.java
@@ -1,0 +1,27 @@
+package org.yapp.sse.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.yapp.core.sse.FluxSsePersonalService;
+import reactor.core.publisher.Flux;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/sse")
+public class SseController {
+
+    private final FluxSsePersonalService ssePersonalService;
+
+    @PreAuthorize(value = "hasRole('USER')")
+    @GetMapping("/personal")
+    @Operation(summary = "SSE 연결", description = "로그인한 회원에대한 event 수신 stream을 얻습니다", tags = {"SSE"})
+    public Flux<ServerSentEvent<Object>> streamEvents(@AuthenticationPrincipal Long userId) {
+        return ssePersonalService.connect(userId);
+    }
+}

--- a/core/exception/src/main/java/org/yapp/core/exception/error/code/ProfileErrorCode.java
+++ b/core/exception/src/main/java/org/yapp/core/exception/error/code/ProfileErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ProfileErrorCode implements ErrorCode {
     INACTIVE_PROFILE(HttpStatus.FORBIDDEN, "비활성화 프로필입니다."),
     NOTFOUND_PROFILE(HttpStatus.NOT_FOUND, "존재하지 않는 프로필입니다."),
-    ;
+    INVALID_PROFILE_IMAGE_TYPE(HttpStatus.BAD_REQUEST,
+        "지원되지 않는 파일 형식입니다. (허용된 타입: JPEG, PNG, WEBP)");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/core/sse/build.gradle
+++ b/core/sse/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id 'java'
+}
+
+group = 'org.yapp'
+version = '0.0.1-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
+    testImplementation platform('org.junit:junit-bom:5.10.0')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/core/sse/src/main/java/org/yapp/core/sse/FluxSsePersonalService.java
+++ b/core/sse/src/main/java/org/yapp/core/sse/FluxSsePersonalService.java
@@ -1,0 +1,58 @@
+package org.yapp.core.sse;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.stereotype.Service;
+import org.yapp.core.sse.dto.SsePayload;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
+import reactor.core.publisher.Sinks.Many;
+
+@Service
+@Slf4j
+public class FluxSsePersonalService implements SsePersonalService {
+
+    private final Map<Long, Many<ServerSentEvent<Object>>> userSinks = new ConcurrentHashMap<>();
+
+    public Flux<ServerSentEvent<Object>> connect(Long userId) {
+        Sinks.Many<ServerSentEvent<Object>> sink = userSinks.compute(userId,
+            (key, existingSink) -> {
+                if (existingSink != null) {
+                    existingSink.tryEmitComplete();
+                }
+                return Sinks.many().unicast().onBackpressureBuffer();
+            });
+
+        return sink.asFlux()
+            .doOnCancel(() -> {
+                log.info("User {} SSE connection canceled by client", userId);
+                this.disconnect(userId);
+            })
+            .doFinally(signalType -> {
+                log.info("User {} SSE connection closed. Signal: {}", userId, signalType);
+                this.disconnect(userId);
+            });
+    }
+
+    public void sendToPersonal(Long userId, SsePayload<Object> ssePayload) {
+        Sinks.Many<ServerSentEvent<Object>> sink = userSinks.get(userId);
+        if (sink != null) {
+            sink.tryEmitNext(ServerSentEvent.builder()
+                .id(ssePayload.getId())
+                .event(ssePayload.getEventType().toString())
+                .comment(ssePayload.getComment())
+                .retry(ssePayload.getRetry())
+                .data(ssePayload.getData())
+                .build());
+        }
+    }
+
+    public void disconnect(Long userId) {
+        Sinks.Many<ServerSentEvent<Object>> sink = userSinks.remove(userId);
+        if (sink != null) {
+            sink.tryEmitComplete();
+        }
+    }
+}

--- a/core/sse/src/main/java/org/yapp/core/sse/SsePersonalService.java
+++ b/core/sse/src/main/java/org/yapp/core/sse/SsePersonalService.java
@@ -1,0 +1,12 @@
+package org.yapp.core.sse;
+
+import org.yapp.core.sse.dto.SsePayload;
+
+public interface SsePersonalService {
+
+    public Object connect(Long userId);
+
+    public void sendToPersonal(Long userId, SsePayload<Object> data);
+
+    public void disconnect(Long userId);
+}

--- a/core/sse/src/main/java/org/yapp/core/sse/dto/EventType.java
+++ b/core/sse/src/main/java/org/yapp/core/sse/dto/EventType.java
@@ -1,0 +1,7 @@
+package org.yapp.core.sse.dto;
+
+public enum EventType {
+    HEARTBEAT,
+    NOTIFICATION,
+    MESSAGE,
+}

--- a/core/sse/src/main/java/org/yapp/core/sse/dto/SsePayload.java
+++ b/core/sse/src/main/java/org/yapp/core/sse/dto/SsePayload.java
@@ -1,0 +1,37 @@
+package org.yapp.core.sse.dto;
+
+import java.time.Duration;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class SsePayload<T> {
+
+    private static final EventType DEFAULT_EVENT_TYPE = EventType.NOTIFICATION;
+    private static final Duration DEFAULT_DURATION = Duration.ofMinutes(10);
+    private static final String DEFAULT_COMMENT = "SSE Payload";
+    private static final Duration DEFAULT_RETRY = Duration.ofSeconds(5);
+
+    private String id;
+    private EventType eventType;
+    private Duration duration;
+    private String comment;
+    private Duration retry;
+    private T data;
+
+    public static <T> SsePayload<T> of(String id, EventType eventType, T data) {
+        return SsePayload.<T>builder()
+            .id(id != null ? id : UUID.randomUUID().toString())
+            .eventType(eventType != null ? eventType : DEFAULT_EVENT_TYPE)
+            .duration(DEFAULT_DURATION)
+            .comment(DEFAULT_COMMENT)
+            .retry(DEFAULT_RETRY)
+            .data(data)
+            .build();
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,4 +17,6 @@ include 'infra:redis'
 findProject(':infra:redis')?.name = 'redis'
 include 'infra:sms'
 findProject(':infra:sms')?.name = 'sms'
+include 'core:sse'
+findProject(':core:sse')?.name = 'sse'
 


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-478](https://yapp25app3.atlassian.net/browse/PC-478)
## ✨ 작업 내용

- core:sse 모듈 생성
- SsePersionalService 인터페이스 생성
- FluxSsePersionalService 구현체 생성
- sse 연결 API 구현

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항

## 📋 참고 사항
- 코드 리뷰 시 논의가 필요한 사항이나 배포 관련 주의 사항을 추가합니다.
@PreAuthorize(value = "hasRole('USER')")
이렇게 sse 연결 api에 USER 권한을 가진 회원만 접근가능하도록 설정했는데, 저게 작동을 안 하는 것 같아요.
Authorization 헤더에 빈 값을 넣고 요청을 보내면 내부에서 userId가 null 이라고 에러를 뱉네요 ,,


[PC-478]: https://yapp25app3.atlassian.net/browse/PC-478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ