### PR TITLE
[PC-545] 프로필 생성시 AI 요약

### DIFF
--- a/api/src/main/java/org/yapp/domain/auth/presentation/SmsAuthController.java
+++ b/api/src/main/java/org/yapp/domain/auth/presentation/SmsAuthController.java
@@ -3,6 +3,7 @@ package org.yapp.domain.auth.presentation;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,10 +34,11 @@ public class SmsAuthController {
     @PostMapping("/code/verify")
     @Operation(summary = "SMS 인증번호 검증", description = "받은 인증번호를 검증합니다.", tags = {"SMS 인증"})
     public ResponseEntity<CommonResponse<OauthLoginResponse>> verifyCode(
-        @RequestBody SmsAuthVerifyRequest request) {
+        @RequestBody SmsAuthVerifyRequest request,
+        @AuthenticationPrincipal Long userId) {
         smsAuthService.verifySmsAuthCode(request.getPhoneNumber(), request.getCode());
         OauthLoginResponse registerToken = userService.registerPhoneNumber(
-            request.getPhoneNumber());
+            userId, request.getPhoneNumber());
         return ResponseEntity.ok(CommonResponse.createSuccess(registerToken));
     }
 }

--- a/api/src/main/java/org/yapp/domain/profile/application/ProfileValueTalkSummaryService.java
+++ b/api/src/main/java/org/yapp/domain/profile/application/ProfileValueTalkSummaryService.java
@@ -30,28 +30,52 @@ public class ProfileValueTalkSummaryService {
 
     private static final String SYSTEM_PROMPT = """
             사용자가 작성한 자기소개 또는 가치관 관련 글을 요약해, 상대방이 매력을 느낄 수 있도록 자연스럽고 긍정적인 문장으로 정리해 주세요.
-        
             친근하면서도 진솔한 느낌을 살려 주세요.
             너무 일반적인 표현(예: "좋은 사람을 만나고 싶어요")은 피하고, 개성을 드러낼 수 있도록 해 주세요.
             문장은 짧고 명확하게 작성해 주세요.
             최대 50자로 요약해 주세요.
-        
-            예시 입력:
-            "여행을 정말 좋아해요! 특히 혼자 떠나는 여행에서 새로운 사람들과 이야기를 나누는 걸 좋아합니다. 주말에는 가까운 곳이라도 가볍게 나들이 가는 걸 즐기고, 때로는 집에서 독서를 하면서 조용한 시간을 보내기도 해요. 감성적인 영화 보는 것도 좋아해서, 좋은 영화 추천해 주시면 너무 반가울 것 같아요!"
-        
-            예시 출력:
-            "새로운 경험과 사람을 좋아하는 여행 마니아! 가벼운 나들이부터 감성적인 영화 감상까지, 일상의 작은 순간들을 소중히 여깁니다."
         """;
 
     private static final String TEXT_CONDITION = " (제약조건: 글자수 최대 20자, 특수문자 제외)";
 
     @Transactional(readOnly = true)
-    public void summaryProfileValueTalks(Long userId) {
+    public void summaryProfileValueTalksAsync(Long userId) {
+        List<Mono<ProfileValueTalkSummaryResponse>> summarizeTasks = getSummaryTasks(userId);
+
+        Flux.merge(summarizeTasks)
+            .collectList()
+            .publishOn(Schedulers.boundedElastic()) // 비동기 처리
+            .doOnSuccess(profileValueTalkSummaryResponses -> {
+                profileValueTalkSummaryResponses.forEach(response -> {
+                    profileValueTalkService.updateSummary(response.profileValueTalkId(),
+                        response.summary());
+                });
+            })
+            .subscribe();
+    }
+
+    @Transactional
+    public void summaryProfileValueTalksSync(Profile profile) {
+        List<Mono<ProfileValueTalkSummaryResponse>> summarizeTasks = getSummaryTasks(profile);
+
+        List<ProfileValueTalkSummaryResponse> results = Flux.merge(summarizeTasks)
+            .collectList()
+            .block();
+
+        if (results != null) {
+            results.forEach(response -> {
+                profileValueTalkService.updateSummary(response.profileValueTalkId(),
+                    response.summary());
+            });
+        }
+    }
+
+    private List<Mono<ProfileValueTalkSummaryResponse>> getSummaryTasks(Long userId) {
         User user = userService.getUserById(userId);
         Profile profile = user.getProfile();
         List<ProfileValueTalk> profileValueTalks = profile.getProfileValueTalks();
 
-        List<Mono<ProfileValueTalkSummaryResponse>> summarizeTasks = profileValueTalks.stream()
+        return profileValueTalks.stream()
             .map(profileValueTalk -> summarizationService.summarize(SYSTEM_PROMPT,
                     profileValueTalk.getAnswer() + TEXT_CONDITION)
                 .map(summarizedAnswer -> {
@@ -63,25 +87,25 @@ public class ProfileValueTalkSummaryService {
                         summarizedAnswer);
                 }))
             .toList();
+    }
 
-        Flux.merge(summarizeTasks)
-            .collectList()
-            .publishOn(Schedulers.boundedElastic())
-            .doOnSuccess(profileValueTalkSummaryResponses -> {
-                profileValueTalkSummaryResponses.forEach(profileValueTalkSummaryResponse -> {
-                    profileValueTalkService.updateSummary(
-                        profileValueTalkSummaryResponse.profileValueTalkId(),
-                        profileValueTalkSummaryResponse.summary());
-                });
-            })
-            .subscribe();
+    private List<Mono<ProfileValueTalkSummaryResponse>> getSummaryTasks(Profile profile) {
+        List<ProfileValueTalk> profileValueTalks = profile.getProfileValueTalks();
+
+        return profileValueTalks.stream()
+            .map(profileValueTalk -> summarizationService.summarize(SYSTEM_PROMPT,
+                    profileValueTalk.getAnswer() + TEXT_CONDITION)
+                .map(summarizedAnswer -> {
+                    summarizedAnswer = summarizedAnswer.replaceAll("[\"']", "");
+                    return new ProfileValueTalkSummaryResponse(profileValueTalk.getId(),
+                        summarizedAnswer);
+                }))
+            .toList();
     }
 
     private void sentSummaryResponse(Long userId, Long profileValueTalkId, String summary) {
         ProfileValueTalkSummaryResponse response = new ProfileValueTalkSummaryResponse(
-            profileValueTalkId,
-            summary
-        );
+            profileValueTalkId, summary);
 
         ssePersonalService.sendToPersonal(userId, SsePayload.of(
             null, EventType.PROFILE_TALK_SUMMARY_MESSAGE, response

--- a/api/src/main/java/org/yapp/domain/profile/application/ProfileValueTalkSummaryService.java
+++ b/api/src/main/java/org/yapp/domain/profile/application/ProfileValueTalkSummaryService.java
@@ -31,12 +31,13 @@ public class ProfileValueTalkSummaryService {
     private static final String SYSTEM_PROMPT = """
             사용자가 작성한 자기소개 또는 가치관 관련 글을 요약해, 상대방이 매력을 느낄 수 있도록 자연스럽고 긍정적인 문장으로 정리해 주세요.
             친근하면서도 진솔한 느낌을 살려 주세요.
+            자신의 가치관을 잘 전달하게 작성해주세요.
             너무 일반적인 표현(예: "좋은 사람을 만나고 싶어요")은 피하고, 개성을 드러낼 수 있도록 해 주세요.
             문장은 짧고 명확하게 작성해 주세요.
             최대 50자로 요약해 주세요.
         """;
 
-    private static final String TEXT_CONDITION = " (제약조건: 글자수 최대 20자, 특수문자 제외)";
+    private static final String TEXT_CONDITION = " (제약조건: 글자수 최대 50자, 특수문자 금지)";
 
     @Transactional(readOnly = true)
     public void summaryProfileValueTalksAsync(Long userId) {

--- a/api/src/main/java/org/yapp/domain/profile/presentation/ProfileController.java
+++ b/api/src/main/java/org/yapp/domain/profile/presentation/ProfileController.java
@@ -53,10 +53,14 @@ public class ProfileController {
     @PostMapping("")
     @Operation(summary = "프로필 생성", description = "현재 로그인된 사용자의 프로필을 생성합니다.", tags = {"프로필"})
     public ResponseEntity<CommonResponse<OauthLoginResponse>> createProfile(
-        @RequestBody @Valid ProfileCreateRequest request) {
+        @RequestBody @Valid ProfileCreateRequest request,
+        @AuthenticationPrincipal Long userId) {
 
         Profile profile = profileService.create(request);
-        OauthLoginResponse oauthLoginResponse = userService.completeProfileInitialize(profile);
+        profileValueTalkSummaryService.summaryProfileValueTalksSync(profile);
+        OauthLoginResponse oauthLoginResponse = userService.completeProfileInitialize(userId,
+            profile);
+
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(CommonResponse.createSuccess(oauthLoginResponse));
     }
@@ -135,7 +139,7 @@ public class ProfileController {
         @RequestBody ProfileValueTalkUpdateRequest request) {
 
         profileService.updateProfileValueTalks(userId, request);
-        profileValueTalkSummaryService.summaryProfileValueTalks(userId);
+        profileValueTalkSummaryService.summaryProfileValueTalksAsync(userId);
 
         ProfileValueTalkResponses profileValueTalkResponses = profileValueTalkService.getProfileValueTalkResponses(
             userId);

--- a/api/src/main/java/org/yapp/domain/profile/presentation/ProfileController.java
+++ b/api/src/main/java/org/yapp/domain/profile/presentation/ProfileController.java
@@ -12,6 +12,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,6 +31,7 @@ import org.yapp.domain.profile.application.ProfileValueTalkService;
 import org.yapp.domain.profile.application.ProfileValueTalkSummaryService;
 import org.yapp.domain.profile.presentation.request.ProfileBasicUpdateRequest;
 import org.yapp.domain.profile.presentation.request.ProfileCreateRequest;
+import org.yapp.domain.profile.presentation.request.ProfileTalkSummaryUpdateRequest;
 import org.yapp.domain.profile.presentation.request.ProfileValuePickUpdateRequest;
 import org.yapp.domain.profile.presentation.request.ProfileValueTalkUpdateRequest;
 import org.yapp.domain.profile.presentation.response.ProfileBasicResponse;
@@ -148,6 +151,18 @@ public class ProfileController {
             .body(CommonResponse.createSuccess(profileValueTalkResponses));
     }
 
+    @PatchMapping("/valueTalks/{profileTalkId}/summary")
+    @Operation(summary = "프로필 가치관 Talk 요약 업데이트", description = "프로필 가치관 Talk 요약을 사용자 입력값으로 업데이트합니다.", tags = {
+        "프로필"
+    })
+    public ResponseEntity<CommonResponse<Void>> updateProfileTalkSummary(
+        @PathVariable Long profileTalkId,
+        @Valid @RequestBody ProfileTalkSummaryUpdateRequest request) {
+        profileValueTalkService.updateSummary(profileTalkId, request.summary());
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(CommonResponse.createSuccessWithNoContent("요약 업데이트가 성공하였습니다."));
+    }
 
     @PostMapping("/check-nickname")
     @Operation(summary = "프로필 닉네임 중복 확인", description = "요청 파라미터로 전달된 닉네임이 중복되는지 확인합니다.", tags = {

--- a/api/src/main/java/org/yapp/domain/profile/presentation/request/ProfileTalkSummaryUpdateRequest.java
+++ b/api/src/main/java/org/yapp/domain/profile/presentation/request/ProfileTalkSummaryUpdateRequest.java
@@ -4,6 +4,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record ProfileTalkSummaryUpdateRequest(
-    @NotBlank(message = "요약 내용은 필수 입력 사항입니다.") @Size(max = 20, message = "요약 내용은 최대 20자까지 입력할 수 있습니다.") String summary) {
+    @NotBlank(message = "요약 내용은 필수 입력 사항입니다.") @Size(max = 50, message = "요약 내용은 최대 20자까지 입력할 수 있습니다.") String summary) {
 
 }

--- a/api/src/main/java/org/yapp/domain/profile/presentation/request/ProfileTalkSummaryUpdateRequest.java
+++ b/api/src/main/java/org/yapp/domain/profile/presentation/request/ProfileTalkSummaryUpdateRequest.java
@@ -1,0 +1,9 @@
+package org.yapp.domain.profile.presentation.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ProfileTalkSummaryUpdateRequest(
+    @NotBlank(message = "요약 내용은 필수 입력 사항입니다.") @Size(max = 20, message = "요약 내용은 최대 20자까지 입력할 수 있습니다.") String summary) {
+
+}

--- a/api/src/main/java/org/yapp/domain/user/application/UserService.java
+++ b/api/src/main/java/org/yapp/domain/user/application/UserService.java
@@ -3,7 +3,6 @@ package org.yapp.domain.user.application;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.yapp.core.auth.AuthenticationService;
 import org.yapp.core.auth.jwt.JwtUtil;
 import org.yapp.core.domain.profile.Profile;
 import org.yapp.core.domain.user.RoleStatus;
@@ -18,7 +17,6 @@ import org.yapp.domain.user.dao.UserRepository;
 public class UserService {
 
     private final UserRepository userRepository;
-    private final AuthenticationService authenticationService;
     private final JwtUtil jwtUtil;
 
     /**
@@ -27,8 +25,7 @@ public class UserService {
      * @return 액세스토큰과 리프레시 토큰
      */
     @Transactional
-    public OauthLoginResponse completeProfileInitialize(Profile profile) {
-        Long userId = authenticationService.getUserId();
+    public OauthLoginResponse completeProfileInitialize(Long userId, Profile profile) {
         User user =
             userRepository.findById(userId)
                 .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
@@ -53,8 +50,7 @@ public class UserService {
      * @return 액세스토큰과 리프레시 토큰
      */
     @Transactional
-    public OauthLoginResponse registerPhoneNumber(String phoneNumber) {
-        Long userId = authenticationService.getUserId();
+    public OauthLoginResponse registerPhoneNumber(Long userId, String phoneNumber) {
         User user =
             userRepository.findById(userId)
                 .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));

--- a/api/src/main/java/org/yapp/sse/presentation/SseController.java
+++ b/api/src/main/java/org/yapp/sse/presentation/SseController.java
@@ -2,13 +2,16 @@ package org.yapp.sse.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.yapp.core.sse.FluxSsePersonalService;
+import org.yapp.format.CommonResponse;
 import reactor.core.publisher.Flux;
 
 @RestController
@@ -23,5 +26,13 @@ public class SseController {
     @Operation(summary = "SSE 연결", description = "로그인 회원에 대한 이벤트 수신 스트림을 얻습니다", tags = {"SSE"})
     public Flux<ServerSentEvent<Object>> connect(@AuthenticationPrincipal Long userId) {
         return ssePersonalService.connect(userId);
+    }
+
+    @PreAuthorize(value = "hasRole('USER')")
+    @DeleteMapping("/personal/disconnect")
+    @Operation(summary = "SSE 연결 해제", description = "로그인 회원의 SSE 연결을 해제합니다", tags = {"SSE"})
+    public ResponseEntity<CommonResponse<Void>> disconnect(@AuthenticationPrincipal Long userId) {
+        ssePersonalService.disconnect(userId);
+        return ResponseEntity.ok(CommonResponse.createSuccessWithNoContent("SSE 연결이 해제 되었습니다"));
     }
 }

--- a/api/src/main/java/org/yapp/sse/presentation/SseController.java
+++ b/api/src/main/java/org/yapp/sse/presentation/SseController.java
@@ -21,7 +21,7 @@ public class SseController {
     @PreAuthorize(value = "hasRole('USER')")
     @PostMapping("/personal/connect")
     @Operation(summary = "SSE 연결", description = "로그인 회원에 대한 이벤트 수신 스트림을 얻습니다", tags = {"SSE"})
-    public Flux<ServerSentEvent<Object>> streamEvents(@AuthenticationPrincipal Long userId) {
+    public Flux<ServerSentEvent<Object>> connect(@AuthenticationPrincipal Long userId) {
         return ssePersonalService.connect(userId);
     }
 }

--- a/api/src/main/java/org/yapp/sse/presentation/SseController.java
+++ b/api/src/main/java/org/yapp/sse/presentation/SseController.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.yapp.core.sse.FluxSsePersonalService;
@@ -19,7 +19,7 @@ public class SseController {
     private final FluxSsePersonalService ssePersonalService;
 
     @PreAuthorize(value = "hasRole('USER')")
-    @GetMapping("/personal")
+    @PostMapping("/personal/connect")
     @Operation(summary = "SSE 연결", description = "로그인 회원에 대한 이벤트 수신 스트림을 얻습니다", tags = {"SSE"})
     public Flux<ServerSentEvent<Object>> streamEvents(@AuthenticationPrincipal Long userId) {
         return ssePersonalService.connect(userId);

--- a/api/src/main/java/org/yapp/sse/presentation/SseController.java
+++ b/api/src/main/java/org/yapp/sse/presentation/SseController.java
@@ -20,7 +20,7 @@ public class SseController {
 
     @PreAuthorize(value = "hasRole('USER')")
     @GetMapping("/personal")
-    @Operation(summary = "SSE 연결", description = "로그인 회원에대한 event 수신 stream을 얻습니다", tags = {"SSE"})
+    @Operation(summary = "SSE 연결", description = "로그인 회원에 대한 이벤트 수신 스트림을 얻습니다", tags = {"SSE"})
     public Flux<ServerSentEvent<Object>> streamEvents(@AuthenticationPrincipal Long userId) {
         return ssePersonalService.connect(userId);
     }

--- a/core/sse/src/main/java/org/yapp/core/sse/FluxSsePersonalService.java
+++ b/core/sse/src/main/java/org/yapp/core/sse/FluxSsePersonalService.java
@@ -21,8 +21,14 @@ public class FluxSsePersonalService implements SsePersonalService {
 
             sink.onDispose(() -> {
                 userSinks.remove(userId);
-                log.info("사용자 {} SSE 연결이 종료되었습니다.", userId);
+                log.info("#onDispose 사용자 {} SSE 연결이 종료되었습니다.", userId);
             });
+
+            sink.onCancel(() -> {
+                this.disconnect(userId);
+                log.info("#onCancel 사용자 {} SSE 연결이 종료되었습니다.", userId);
+            });
+
         }, FluxSink.OverflowStrategy.BUFFER);
     }
 
@@ -42,7 +48,6 @@ public class FluxSsePersonalService implements SsePersonalService {
         if (sink != null) {
             try {
                 sink.complete();
-                log.info("사용자 {} SSE 연결이 성공적으로 종료되었습니다.", userId);
             } catch (Exception e) {
                 log.warn("사용자 {} SSE 연결 종료 실패: {}", userId, e.getMessage());
             }

--- a/infra/ai/src/main/java/org/yapp/infra/ai/application/ClovaChatSummarizationService.java
+++ b/infra/ai/src/main/java/org/yapp/infra/ai/application/ClovaChatSummarizationService.java
@@ -52,7 +52,7 @@ public class ClovaChatSummarizationService implements SummarizationService {
                 ),
                 "topP", 0.8,
                 "topK", 0,
-                "maxTokens", 10,
+                "maxTokens", 30,
                 "temperature", 0.8,
                 "repeatPenalty", 8.0,
                 "stopBefore", List.of(),


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-545](https://yapp25app3.atlassian.net/browse/PC-545)

## ✨ 작업 내용
- UserService에서 AuthenticationService를 사용하지 안도록 변경
- AI 요약 동기 / 비동기 구분
- 프로필 생성시 AI 요약 동기 진행
- Sse FluxSink 적용 

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항
- 프로필 요약 데이터를 여러 쓰레드에서 전달하기 위해, thread-safe한 Sse FluxSink로 sink를 변경하였습니다. 

## 📋 참고 사항


[PC-545]: https://yapp25app3.atlassian.net/browse/PC-545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ