### PR TITLE
[PC-580] 프로필 가치관 톡 조회 응답 형식 변경

### DIFF
--- a/api/src/main/java/org/yapp/domain/profile/presentation/response/ProfileValueTalkResponse.java
+++ b/api/src/main/java/org/yapp/domain/profile/presentation/response/ProfileValueTalkResponse.java
@@ -1,22 +1,30 @@
 package org.yapp.domain.profile.presentation.response;
 
+import java.util.List;
 import org.yapp.core.domain.profile.ProfileValueTalk;
+import org.yapp.core.domain.value.ValueTalk;
 
 public record ProfileValueTalkResponse(
     String title,
     String category,
     Long profileValueTalkId,
     String answer,
-    String summary
+    String summary,
+    String placeholder,
+    List<String> guides
 ) {
 
-    public ProfileValueTalkResponse(ProfileValueTalk profileValueTalk) {
-        this(
-            profileValueTalk.getValueTalk().getTitle(),
-            profileValueTalk.getValueTalk().getCategory(),
+    public static ProfileValueTalkResponse from(ProfileValueTalk profileValueTalk) {
+        ValueTalk valueTalk = profileValueTalk.getValueTalk();
+
+        return new ProfileValueTalkResponse(
+            valueTalk.getTitle(),
+            valueTalk.getCategory(),
             profileValueTalk.getId(),
             profileValueTalk.getAnswer(),
-            profileValueTalk.getSummary()
+            profileValueTalk.getSummary(),
+            valueTalk.getPlaceholder(),
+            valueTalk.getGuides()
         );
     }
 }

--- a/api/src/main/java/org/yapp/domain/profile/presentation/response/ProfileValueTalkResponses.java
+++ b/api/src/main/java/org/yapp/domain/profile/presentation/response/ProfileValueTalkResponses.java
@@ -7,7 +7,7 @@ public record ProfileValueTalkResponses(List<ProfileValueTalkResponse> responses
 
     public static ProfileValueTalkResponses from(List<ProfileValueTalk> profileValueTalks) {
         List<ProfileValueTalkResponse> profileValueTalkResponses = profileValueTalks.stream()
-            .map(ProfileValueTalkResponse::new).toList();
+            .map(ProfileValueTalkResponse::from).toList();
 
         return new ProfileValueTalkResponses(profileValueTalkResponses);
     }


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-580]

## ✨ 작업 내용
- 프로필 가치관 톡 조회시 guides와 placeholder 데이터를 추가로 전달합니다.

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항

## 📋 참고 사항
- 코드 리뷰 시 논의가 필요한 사항이나 배포 관련 주의 사항을 추가합니다.


[PC-580]: https://yapp25app3.atlassian.net/browse/PC-580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ