### PR TITLE
[PC-175] 애플 소셜 로그인 기능 

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation project(':infra:ai')
 
     implementation('org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0');
+    implementation('org.bouncycastle:bcpkix-jdk18on:1.76');
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 

--- a/api/src/main/java/org/yapp/domain/auth/application/oauth/apple/AppleIdTokenDecoder.java
+++ b/api/src/main/java/org/yapp/domain/auth/application/oauth/apple/AppleIdTokenDecoder.java
@@ -1,0 +1,81 @@
+package org.yapp.domain.auth.application.oauth.apple;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import java.math.BigInteger;
+import java.net.URL;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AppleIdTokenDecoder {
+
+    private static final String APPLE_KEYS_URL = "https://appleid.apple.com/auth/keys";
+
+    public Claims decodeIdToken(String idToken) {
+        try {
+            JsonNode appleKeys = fetchApplePublicKeys();
+            String kid = extractKidFromIdToken(idToken);
+
+            JsonNode matchedKey = findMatchingKey(appleKeys, kid);
+            if (matchedKey == null) {
+                throw new RuntimeException("No matching key found for kid: " + kid);
+            }
+
+            PublicKey publicKey = buildPublicKey(matchedKey);
+
+            Jws<Claims> claimsJws = Jwts.parser()
+                .setSigningKey(publicKey)
+                .build()
+                .parseClaimsJws(idToken);
+
+            return claimsJws.getBody(); // Payload 반환
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to decode idToken", e);
+        }
+    }
+
+    private JsonNode fetchApplePublicKeys() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        URL url = new URL(APPLE_KEYS_URL);
+        return objectMapper.readTree(url).get("keys");
+    }
+
+    private String extractKidFromIdToken(String idToken) throws JsonProcessingException {
+        String[] parts = idToken.split("\\.");
+        if (parts.length != 3) {
+            throw new IllegalArgumentException("Invalid idToken format");
+        }
+        String header = new String(Base64.getDecoder().decode(parts[0]));
+        JsonNode headerJson = new ObjectMapper().readTree(header);
+        return headerJson.get("kid").asText();
+    }
+
+    private JsonNode findMatchingKey(JsonNode appleKeys, String kid) {
+        for (JsonNode key : appleKeys) {
+            if (key.get("kid").asText().equals(kid)) {
+                return key;
+            }
+        }
+        return null;
+    }
+
+    private PublicKey buildPublicKey(JsonNode keyInfo) throws Exception {
+        String n = keyInfo.get("n").asText();
+        String e = keyInfo.get("e").asText();
+
+        BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(n));
+        BigInteger exponent = new BigInteger(1, Base64.getUrlDecoder().decode(e));
+
+        RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(modulus, exponent);
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        return keyFactory.generatePublic(publicKeySpec);
+    }
+}

--- a/api/src/main/java/org/yapp/domain/auth/application/oauth/apple/AppleOauthClient.java
+++ b/api/src/main/java/org/yapp/domain/auth/application/oauth/apple/AppleOauthClient.java
@@ -1,0 +1,75 @@
+package org.yapp.domain.auth.application.oauth.apple;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.yapp.core.exception.ApplicationException;
+import org.yapp.core.exception.error.code.AuthErrorCode;
+import org.yapp.domain.auth.application.oauth.OauthClient;
+import org.yapp.domain.auth.application.oauth.apple.dto.AppleAuthResponse;
+import org.yapp.global.config.AppleOauthProperties;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AppleOauthClient implements OauthClient {
+
+    private final AppleOauthHelper appleOauthHelper;
+    private final AppleOauthProperties appleOauthProperties;
+    private final RestTemplate restTemplate;
+
+    public AppleAuthResponse getAppleAuthResponse(
+        String clientId,
+        String clientSecret,
+        String grantType,
+        String authorizationCode
+    ) {
+        String url = "https://appleid.apple.com/auth/token";
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("grant_type", grantType);
+        params.add("code", authorizationCode);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(params, headers);
+        try {
+            ResponseEntity<AppleAuthResponse> response = restTemplate.postForEntity(
+                url, entity, AppleAuthResponse.class
+            );
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                return response.getBody();
+            } else {
+                throw new ApplicationException(AuthErrorCode.ID_TOKEN_NOT_FOUND);
+            }
+        } catch (Exception e) {
+            throw new ApplicationException(AuthErrorCode.OAUTH_ERROR);
+        }
+    }
+
+    @Override
+    public String getOAuthProviderUserId(String authorizationCode) {
+        String clientSecret = appleOauthHelper.generateClientSecret();
+        AppleAuthResponse appleAuthResponse = this.getAppleAuthResponse(
+            appleOauthProperties.getClientId(),
+            clientSecret,
+            "authorization_code",
+            authorizationCode
+        );
+        String idToken = appleAuthResponse.getIdToken();
+        Claims idTokenClaims = appleOauthHelper.decodeIdToken(idToken);
+        if (idTokenClaims.containsKey("sub")) {
+            return idTokenClaims.get("sub", String.class);
+        } else {
+            throw new ApplicationException(AuthErrorCode.OAUTH_ID_NOT_FOUND);
+        }
+    }
+}

--- a/api/src/main/java/org/yapp/domain/auth/application/oauth/apple/AppleOauthHelper.java
+++ b/api/src/main/java/org/yapp/domain/auth/application/oauth/apple/AppleOauthHelper.java
@@ -1,0 +1,58 @@
+package org.yapp.domain.auth.application.oauth.apple;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.security.PrivateKey;
+import java.security.Security;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Base64;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.springframework.stereotype.Component;
+import org.yapp.global.config.AppleOauthProperties;
+
+@Component
+@RequiredArgsConstructor
+public class AppleOauthHelper {
+
+    private final AppleOauthProperties appleProperties;
+    private final AppleIdTokenDecoder appleIdTokenDecoder;
+
+    public String generateClientSecret() {
+        LocalDateTime expiration = LocalDateTime.now().plusMinutes(5);
+
+        return Jwts.builder()
+            .claim("iss", appleProperties.getTeamId())
+            .claim("aud", appleProperties.getAuthServer())
+            .claim("sub", appleProperties.getClientId())
+            .claim("exp", Date.from(expiration.atZone(ZoneId.systemDefault()).toInstant()))
+            .claim("iat", new Date())
+            .header()
+            .add("kid", appleProperties.getKeyId())
+            .and()
+            .signWith(getPrivateKey())
+            .compact();
+    }
+
+    public Claims decodeIdToken(String idToken) {
+        return this.appleIdTokenDecoder.decodeIdToken(idToken);
+    }
+
+    private PrivateKey getPrivateKey() {
+        Security.addProvider(new BouncyCastleProvider());
+        JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
+
+        try {
+            byte[] privateKeyBytes = Base64.getDecoder().decode(appleProperties.getPrivateKey());
+
+            PrivateKeyInfo privateKeyInfo = PrivateKeyInfo.getInstance(privateKeyBytes);
+            return converter.getPrivateKey(privateKeyInfo);
+        } catch (Exception e) {
+            throw new RuntimeException("Error converting private key from String", e);
+        }
+    }
+}

--- a/api/src/main/java/org/yapp/domain/auth/application/oauth/apple/AppleOauthProvider.java
+++ b/api/src/main/java/org/yapp/domain/auth/application/oauth/apple/AppleOauthProvider.java
@@ -1,0 +1,24 @@
+package org.yapp.domain.auth.application.oauth.apple;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.yapp.domain.auth.application.oauth.OauthClient;
+import org.yapp.domain.auth.application.oauth.OauthProvider;
+import org.yapp.domain.auth.domain.enums.OauthType;
+
+@Component
+@RequiredArgsConstructor
+public class AppleOauthProvider implements OauthProvider {
+
+    private final AppleOauthClient appleOauthClient;
+
+    @Override
+    public OauthType getOauthType() {
+        return OauthType.APPLE;
+    }
+
+    @Override
+    public OauthClient getOAuthClient() {
+        return this.appleOauthClient;
+    }
+}

--- a/api/src/main/java/org/yapp/domain/auth/application/oauth/apple/dto/AppleAuthResponse.java
+++ b/api/src/main/java/org/yapp/domain/auth/application/oauth/apple/dto/AppleAuthResponse.java
@@ -1,0 +1,21 @@
+package org.yapp.domain.auth.application.oauth.apple.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AppleAuthResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+    @JsonProperty("token_type")
+    private String tokenType;
+    @JsonProperty("expires_in")
+    private int expiresIn;
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+    @JsonProperty("id_token")
+    private String idToken;
+}

--- a/api/src/main/java/org/yapp/domain/auth/application/oauth/service/OauthService.java
+++ b/api/src/main/java/org/yapp/domain/auth/application/oauth/service/OauthService.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.yapp.core.auth.AuthToken;
 import org.yapp.core.auth.AuthTokenGenerator;
-import org.yapp.core.auth.jwt.JwtUtil;
 import org.yapp.core.auth.token.RefreshTokenService;
 import org.yapp.core.domain.user.RoleStatus;
 import org.yapp.core.domain.user.User;
@@ -19,70 +18,73 @@ import org.yapp.domain.user.dao.UserRepository;
 @RequiredArgsConstructor
 public class OauthService {
 
-  private final OauthProviderResolver oauthProviderResolver;
-  private final JwtUtil jwtUtil;
-  private final UserRepository userRepository;
-  private final RefreshTokenService refreshTokenService;
-  private final AuthTokenGenerator authTokenGenerator;
+    private final OauthProviderResolver oauthProviderResolver;
+    private final UserRepository userRepository;
+    private final RefreshTokenService refreshTokenService;
+    private final AuthTokenGenerator authTokenGenerator;
 
-  public OauthLoginResponse login(OauthLoginRequest request) {
-    OauthProvider oauthProvider = oauthProviderResolver.find(request.getProviderName());
-    String oauthId =
-        request.getProviderName() + oauthProvider.getOAuthProviderUserId(request.getToken());
+    public OauthLoginResponse login(OauthLoginRequest request) {
+        OauthProvider oauthProvider = oauthProviderResolver.find(request.getProviderName());
+        String oauthId =
+            request.getProviderName() + oauthProvider.getOAuthProviderUserId(
+                request.getOauthCredential());
 
-    //이미 가입된 유저인지 확인하고 가입되어 있지 않으면 회원가입 처리
-    Optional<User> userOptional = userRepository.findByOauthId(oauthId);
-    if (userOptional.isEmpty()) {
-      User newUser = User.builder().oauthId(oauthId).role(RoleStatus.NONE.getStatus()).build();
-      User savedUser = userRepository.save(newUser);
-      Long userId = savedUser.getId();
-      AuthToken token = authTokenGenerator.generate(userId, savedUser.getOauthId(), "NONE");
-      String accessToken = token.accessToken();
-      String refreshToken = token.refreshToken();
-      refreshTokenService.saveRefreshToken(userId, refreshToken);
-      return new OauthLoginResponse(RoleStatus.NONE.getStatus(), accessToken, refreshToken);
+        //이미 가입된 유저인지 확인하고 가입되어 있지 않으면 회원가입 처리
+        Optional<User> userOptional = userRepository.findByOauthId(oauthId);
+        if (userOptional.isEmpty()) {
+            User newUser = User.builder().oauthId(oauthId).role(RoleStatus.NONE.getStatus())
+                .build();
+            User savedUser = userRepository.save(newUser);
+            Long userId = savedUser.getId();
+            AuthToken token = authTokenGenerator.generate(userId, savedUser.getOauthId(), "NONE");
+            String accessToken = token.accessToken();
+            String refreshToken = token.refreshToken();
+            refreshTokenService.saveRefreshToken(userId, refreshToken);
+            return new OauthLoginResponse(RoleStatus.NONE.getStatus(), accessToken, refreshToken);
+        }
+
+        //이미 가입한 유저인 경우 로그인 처리
+        Long userId = userOptional.get().getId();
+        final User user = userOptional.get();
+
+        AuthToken token = authTokenGenerator.generate(userId, user.getOauthId(), user.getRole());
+        String accessToken = token.accessToken();
+        String refreshToken = token.refreshToken();
+        refreshTokenService.saveRefreshToken(userId, refreshToken);
+
+        //아직 SMS 인증이 완료되지 않음
+        if (user.getRole().equals("NONE")) {
+            return new OauthLoginResponse(RoleStatus.NONE.getStatus(), accessToken, refreshToken);
+        }
+
+        // SMS 인증은 완료되었으나, 프로필 등록을 안함
+        if (user.getRole().equals("REGISTER")) {
+            return new OauthLoginResponse(RoleStatus.REGISTER.getStatus(), accessToken,
+                refreshToken);
+        }
+
+        //프로필 등록은 했지만, 심사중
+        if (user.getRole().equals("PENDING")) {
+            return new OauthLoginResponse(RoleStatus.PENDING.getStatus(), accessToken,
+                refreshToken);
+        }
+
+        // 가입과 프로필 등록까지 완료된 유저
+        return new OauthLoginResponse(user.getRole(), accessToken, refreshToken);
     }
 
-    //이미 가입한 유저인 경우 로그인 처리
-    Long userId = userOptional.get().getId();
-    final User user = userOptional.get();
 
-    AuthToken token = authTokenGenerator.generate(userId, user.getOauthId(), user.getRole());
-    String accessToken = token.accessToken();
-    String refreshToken = token.refreshToken();
-    refreshTokenService.saveRefreshToken(userId, refreshToken);
+    public OauthLoginResponse tmpTokenGet(Long userId) {
+        //이미 가입된 유저인지 확인하고 가입되어 있지 않으면 회원가입 처리
+        Optional<User> userOptional = userRepository.findById(userId);
 
-    //아직 SMS 인증이 완료되지 않음
-    if (user.getRole().equals("NONE")) {
-      return new OauthLoginResponse(RoleStatus.NONE.getStatus(), accessToken, refreshToken);
+        User user = userOptional.get();
+
+        AuthToken token = authTokenGenerator.generate(userId, user.getOauthId(), user.getRole());
+        String accessToken = token.accessToken();
+        String refreshToken = token.refreshToken();
+        refreshTokenService.saveRefreshToken(userId, refreshToken);
+
+        return new OauthLoginResponse(RoleStatus.NONE.getStatus(), accessToken, refreshToken);
     }
-
-    // SMS 인증은 완료되었으나, 프로필 등록을 안함
-    if (user.getRole().equals("REGISTER")) {
-      return new OauthLoginResponse(RoleStatus.REGISTER.getStatus(), accessToken, refreshToken);
-    }
-
-    //프로필 등록은 했지만, 심사중
-    if (user.getRole().equals("PENDING")) {
-      return new OauthLoginResponse(RoleStatus.PENDING.getStatus(), accessToken, refreshToken);
-    }
-
-    // 가입과 프로필 등록까지 완료된 유저
-    return new OauthLoginResponse(user.getRole(), accessToken, refreshToken);
-  }
-
-
-  public OauthLoginResponse tmpTokenGet(Long userId) {
-    //이미 가입된 유저인지 확인하고 가입되어 있지 않으면 회원가입 처리
-    Optional<User> userOptional = userRepository.findById(userId);
-
-    User user = userOptional.get();
-
-    AuthToken token = authTokenGenerator.generate(userId, user.getOauthId(), user.getRole());
-    String accessToken = token.accessToken();
-    String refreshToken = token.refreshToken();
-    refreshTokenService.saveRefreshToken(userId, refreshToken);
-
-    return new OauthLoginResponse(RoleStatus.NONE.getStatus(), accessToken, refreshToken);
-  }
 }

--- a/api/src/main/java/org/yapp/domain/auth/domain/enums/OauthType.java
+++ b/api/src/main/java/org/yapp/domain/auth/domain/enums/OauthType.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum OauthType {
     GOOGLE("google"),
-    KAKAO("kakao");
+    KAKAO("kakao"),
+    APPLE("apple");
 
     private final String typeName;
 }

--- a/api/src/main/java/org/yapp/domain/auth/presentation/dto/request/OauthLoginRequest.java
+++ b/api/src/main/java/org/yapp/domain/auth/presentation/dto/request/OauthLoginRequest.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 public class OauthLoginRequest {
-  private String providerName;
-  private String token;
+
+    private String providerName;
+    private String oauthCredential;
 }

--- a/api/src/main/java/org/yapp/global/config/AppleOauthProperties.java
+++ b/api/src/main/java/org/yapp/global/config/AppleOauthProperties.java
@@ -1,0 +1,20 @@
+package org.yapp.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "app.apple")
+public class AppleOauthProperties {
+
+    private String grantType;
+    private String clientId;
+    private String keyId;
+    private String teamId;
+    private String authServer;
+    private String privateKey;
+}

--- a/core/domain/src/main/java/org/yapp/core/domain/auth/RefreshToken.java
+++ b/core/domain/src/main/java/org/yapp/core/domain/auth/RefreshToken.java
@@ -12,19 +12,20 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Table(name = "refresh_token")
 public class RefreshToken {
-  @Id
-  @Column(name = "user_id")
-  private Long userId;
 
-  @Column(name = "token")
-  private String token;
+    @Id
+    @Column(name = "user_id")
+    private Long userId;
 
-  public RefreshToken(Long userId, String token) {
-    this.userId = userId;
-    this.token = token;
-  }
+    @Column(name = "token", length = 500)
+    private String token;
 
-  public void updateToken(String token) {
-    this.token = token;
-  }
+    public RefreshToken(Long userId, String token) {
+        this.userId = userId;
+        this.token = token;
+    }
+
+    public void updateToken(String token) {
+        this.token = token;
+    }
 }

--- a/core/exception/src/main/java/org/yapp/core/exception/error/code/AuthErrorCode.java
+++ b/core/exception/src/main/java/org/yapp/core/exception/error/code/AuthErrorCode.java
@@ -7,10 +7,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
-    OAUTH_ERROR(HttpStatus.FORBIDDEN, "Oauth Error"),
-    ACCESS_DENIED(HttpStatus.FORBIDDEN, "권한이 없습니다."),
-    ;
-
+    OAUTH_ERROR(HttpStatus.FORBIDDEN, "OAuth 오류"),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    OAUTH_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "OAuth ID를 찾을 수 없습니다."),
+    ID_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "ID 토큰을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-175](https://yapp25app3.atlassian.net/browse/PC-175)

## ✨ 작업 내용
- OauthLoginRequest 필드 이름 수정 (token -> oauthCredential)
- 리프레쉬 토근 길이 수정
- 애플 로그인 기능

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항

## 📋 참고 사항
애플 로그인의 경우 토큰이 아니라, Authorization code 값을 전달 받기 떄문에 OauthLoginRequest에서 token 필드의 이름을 추상화하여 oauthCredential로 변경하였씁니다. 


[PC-175]: https://yapp25app3.atlassian.net/browse/PC-175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ