### PR TITLE
[PC-624] 리프레시 토큰 버그 수정

### DIFF
--- a/api/src/main/java/org/yapp/domain/auth/presentation/LoginController.java
+++ b/api/src/main/java/org/yapp/domain/auth/presentation/LoginController.java
@@ -3,7 +3,6 @@ package org.yapp.domain.auth.presentation;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -53,10 +52,9 @@ public class LoginController {
   @PatchMapping("/token/refresh")
   @Operation(summary = "토큰 리프레시", description = "accessToken과 refreshToken을 갱신합니다.", tags = {"로그인"})
   public ResponseEntity<CommonResponse<RefreshedTokensResponse>> refreshToken(
-      @RequestBody RefreshTokenRequest request,
-      @AuthenticationPrincipal Long userId) {
+      @RequestBody RefreshTokenRequest request) {
     RefreshedTokens refreshedTokens = refreshTokenService.getUserRefreshedTokens(
-        userId, request.getRefreshToken());
+        request.getRefreshToken());
     RefreshedTokensResponse response = new RefreshedTokensResponse(
         refreshedTokens.accessToken(), refreshedTokens.refreshToken());
     return ResponseEntity.ok(CommonResponse.createSuccess(response));

--- a/core/auth/src/main/java/org/yapp/core/auth/token/RefreshTokenService.java
+++ b/core/auth/src/main/java/org/yapp/core/auth/token/RefreshTokenService.java
@@ -27,13 +27,14 @@ public class RefreshTokenService {
   }
 
   @Transactional
-  public RefreshedTokens getUserRefreshedTokens(Long userId,
-      String refreshToken) {
+  public RefreshedTokens getUserRefreshedTokens(String refreshToken) {
+    Long userId = jwtUtil.getUserId(refreshToken);
+    String oauthId = jwtUtil.getOauthId(refreshToken);
+    String role = jwtUtil.getRole(refreshToken);
+
     String expectedRefreshToken = getUserRefreshToken(userId).getToken();
     validateRefreshToken(refreshToken, expectedRefreshToken);
 
-    String oauthId = jwtUtil.getOauthId(refreshToken);
-    String role = jwtUtil.getRole(refreshToken);
     AuthToken token = authTokenGenerator.generate(userId, oauthId, role);
     saveRefreshToken(userId, token.refreshToken());
 


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-624](https://yapp25app3.atlassian.net/browse/PC-624)
## ✨ 작업 내용
- refresh 로직에서 userId 필요없도록 변경
## ✅ 체크리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항

## 📋 참고 사항
- 코드 리뷰 시 논의가 필요한 사항이나 배포 관련 주의 사항을 추가합니다.
