### PR TITLE
[PC-684] FCM 토큰 관련 기능 구현

### DIFF
--- a/api/src/main/java/org/yapp/domain/auth/application/oauth/service/LogoutService.java
+++ b/api/src/main/java/org/yapp/domain/auth/application/oauth/service/LogoutService.java
@@ -3,14 +3,17 @@ package org.yapp.domain.auth.application.oauth.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.yapp.core.auth.token.RefreshTokenService;
+import org.yapp.domain.user.application.UserService;
 
 @Service
 @RequiredArgsConstructor
 public class LogoutService {
 
   private final RefreshTokenService refreshTokenService;
+  private final UserService userService;
 
   public void logout(Long userId) {
+    userService.deleteFcmToken(userId);
     refreshTokenService.deleteRefreshToken(userId);
   }
 }

--- a/api/src/main/java/org/yapp/domain/user/application/UserService.java
+++ b/api/src/main/java/org/yapp/domain/user/application/UserService.java
@@ -1,10 +1,12 @@
 package org.yapp.domain.user.application;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.yapp.core.auth.AuthToken;
 import org.yapp.core.auth.AuthTokenGenerator;
+import org.yapp.core.domain.fcm.FcmToken;
 import org.yapp.core.domain.profile.Profile;
 import org.yapp.core.domain.user.RoleStatus;
 import org.yapp.core.domain.user.User;
@@ -13,9 +15,11 @@ import org.yapp.core.domain.user.UserRejectHistory;
 import org.yapp.core.exception.ApplicationException;
 import org.yapp.core.exception.error.code.UserErrorCode;
 import org.yapp.domain.auth.presentation.dto.response.OauthLoginResponse;
+import org.yapp.domain.user.dao.FcmTokenRepository;
 import org.yapp.domain.user.dao.UserDeleteReasonRepository;
 import org.yapp.domain.user.dao.UserRejectHistoryRepository;
 import org.yapp.domain.user.dao.UserRepository;
+import org.yapp.domain.user.presentation.dto.request.FcmTokenSaveRequest;
 import org.yapp.domain.user.presentation.dto.response.UserBasicInfoResponse;
 import org.yapp.domain.user.presentation.dto.response.UserRejectHistoryResponse;
 
@@ -27,6 +31,7 @@ public class UserService {
   private final UserRejectHistoryRepository userRejectHistoryRepository;
   private final UserDeleteReasonRepository userDeleteReasonRepository;
   private final AuthTokenGenerator authTokenGenerator;
+  private final FcmTokenRepository fcmTokenRepository;
 
   /**
    * Role을 USER로 바꾸고 변경된 토큰을 반환한다.
@@ -96,6 +101,23 @@ public class UserService {
   public void deleteUser(Long userId, String reason) {
     userDeleteReasonRepository.save(new UserDeleteReason(userId, reason));
     userRepository.deleteById(userId);
+  }
+
+  @Transactional
+  public void saveFcmToken(Long userId, FcmTokenSaveRequest request) {
+    Optional<FcmToken> fcmTokenOptional = fcmTokenRepository.findByUserId(userId);
+    if (fcmTokenOptional.isPresent()) {
+      FcmToken fcmToken = fcmTokenOptional.get();
+      fcmToken.updateToken(request.getToken());
+    } else {
+      FcmToken fcmToken = new FcmToken(userId, request.getToken());
+      fcmTokenRepository.save(fcmToken);
+    }
+  }
+
+  @Transactional
+  public void deleteFcmToken(Long userId) {
+    fcmTokenRepository.deleteByUserId(userId);
   }
 
   public UserBasicInfoResponse getUserBasicInfo(Long userId) {

--- a/api/src/main/java/org/yapp/domain/user/dao/FcmTokenRepository.java
+++ b/api/src/main/java/org/yapp/domain/user/dao/FcmTokenRepository.java
@@ -1,0 +1,12 @@
+package org.yapp.domain.user.dao;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.yapp.core.domain.fcm.FcmToken;
+
+public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
+
+  Optional<FcmToken> findByUserId(Long userId);
+
+  void deleteByUserId(Long userId);
+}

--- a/api/src/main/java/org/yapp/domain/user/presentation/UserController.java
+++ b/api/src/main/java/org/yapp/domain/user/presentation/UserController.java
@@ -9,11 +9,13 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.yapp.domain.auth.application.oauth.service.OauthService;
 import org.yapp.domain.user.application.UserService;
+import org.yapp.domain.user.presentation.dto.request.FcmTokenSaveRequest;
 import org.yapp.domain.user.presentation.dto.request.OauthUserDeleteRequest;
 import org.yapp.domain.user.presentation.dto.request.UserDeleteRequest;
 import org.yapp.domain.user.presentation.dto.response.UserBasicInfoResponse;
@@ -68,5 +70,15 @@ public class UserController {
       @AuthenticationPrincipal Long userId) {
     UserBasicInfoResponse userBasicInfo = userService.getUserBasicInfo(userId);
     return ResponseEntity.ok(CommonResponse.createSuccess(userBasicInfo));
+  }
+
+  @PostMapping("/fcm-token")
+  @PreAuthorize(value = "isAuthenticated()")
+  @Operation(summary = "FCM 토큰 등록", description = "FCM 토큰을 등록합니다", tags = {"사용자"})
+  public ResponseEntity<CommonResponse<Void>> saveFcmToken(
+      @AuthenticationPrincipal Long userId,
+      @RequestBody FcmTokenSaveRequest request) {
+    userService.saveFcmToken(userId, request);
+    return ResponseEntity.ok(CommonResponse.createSuccessWithNoContent());
   }
 }

--- a/api/src/main/java/org/yapp/domain/user/presentation/dto/request/FcmTokenSaveRequest.java
+++ b/api/src/main/java/org/yapp/domain/user/presentation/dto/request/FcmTokenSaveRequest.java
@@ -1,0 +1,11 @@
+package org.yapp.domain.user.presentation.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class FcmTokenSaveRequest {
+
+  private String token;
+}

--- a/core/domain/src/main/java/org/yapp/core/domain/fcm/FcmToken.java
+++ b/core/domain/src/main/java/org/yapp/core/domain/fcm/FcmToken.java
@@ -7,9 +7,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor
 @Table(name = "fcm_token")
 public class FcmToken {
 
@@ -21,4 +23,13 @@ public class FcmToken {
   private Long userId;
   @Column(name = "token")
   private String token;
+
+  public FcmToken(Long userId, String token) {
+    this.userId = userId;
+    this.token = token;
+  }
+
+  public void updateToken(String token) {
+    this.token = token;
+  }
 }

--- a/core/exception/src/main/java/org/yapp/core/exception/error/code/AuthErrorCode.java
+++ b/core/exception/src/main/java/org/yapp/core/exception/error/code/AuthErrorCode.java
@@ -7,11 +7,14 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
-    OAUTH_ERROR(HttpStatus.FORBIDDEN, "OAuth 오류"),
-    ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
-    OAUTH_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "OAuth ID를 찾을 수 없습니다."),
-    ID_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "ID 토큰을 찾을 수 없습니다.");
+  OAUTH_ERROR(HttpStatus.FORBIDDEN, "OAuth 오류"),
+  ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+  OAUTH_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "OAuth ID를 찾을 수 없습니다."),
+  ID_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "ID 토큰을 찾을 수 없습니다."),
+  EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+  INVALID_TOKEN_CATEGORY(HttpStatus.UNAUTHORIZED, "토큰의 카테고리가 액세스 토큰이 아닙니다.");
 
-    private final HttpStatus httpStatus;
-    private final String message;
+
+  private final HttpStatus httpStatus;
+  private final String message;
 }


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-684]
## ✨ 작업 내용
- FCM 토큰 저장, 삭제 기능 구현
- FCM 토큰 저장 API 추가
- 로그아웃 시 FCM 토큰 삭제하도록 로직 추가
- 필터단 에러 응답을 RestAdvice 계층과 통일
- 필터단 에러응답의 인코딩 설정
## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항

## 📋 참고 사항



[PC-684]: https://yapp25app3.atlassian.net/browse/PC-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ