### PR TITLE
[PC-000] SSE 요청 권한 수정 및 사용자 기본 정보 응답 포맷 수정

### DIFF
--- a/api/src/main/java/org/yapp/domain/profile/application/ProfileService.java
+++ b/api/src/main/java/org/yapp/domain/profile/application/ProfileService.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.yapp.core.domain.profile.ContactType;
 import org.yapp.core.domain.profile.Profile;
 import org.yapp.core.domain.profile.ProfileBasic;
 import org.yapp.core.domain.profile.ProfileStatus;
@@ -38,22 +37,7 @@ public class ProfileService {
 
     @Transactional
     public Profile create(ProfileCreateRequest dto) {
-        ProfileBasic profileBasic = ProfileBasic.builder()
-            .nickname(dto.nickname())
-            .description(dto.description())
-            .birthdate(dto.birthdate())
-            .height(dto.height())
-            .job(dto.job())
-            .location(dto.location())
-            .smokingStatus(dto.smokingStatus())
-            .weight(dto.weight())
-            .snsActivityLevel(dto.snsActivityLevel())
-            .contacts(dto.contacts().entrySet().stream().collect(Collectors.toMap(
-                entry -> ContactType.valueOf(entry.getKey()),
-                Map.Entry::getValue
-            )))
-            .imageUrl(dto.imageUrl())
-            .build();
+        ProfileBasic profileBasic = dto.toProfileBasic();
 
         Profile profile = Profile.builder().profileBasic(profileBasic)
             .build();

--- a/api/src/main/java/org/yapp/domain/profile/application/ProfileService.java
+++ b/api/src/main/java/org/yapp/domain/profile/application/ProfileService.java
@@ -20,6 +20,7 @@ import org.yapp.core.exception.error.code.ProfileErrorCode;
 import org.yapp.domain.profile.dao.ProfileRepository;
 import org.yapp.domain.profile.presentation.request.ProfileBasicUpdateRequest;
 import org.yapp.domain.profile.presentation.request.ProfileCreateRequest;
+import org.yapp.domain.profile.presentation.request.ProfileUpdateRequest;
 import org.yapp.domain.profile.presentation.request.ProfileValuePickUpdateRequest;
 import org.yapp.domain.profile.presentation.request.ProfileValuePickUpdateRequest.ProfileValuePickPair;
 import org.yapp.domain.profile.presentation.request.ProfileValueTalkUpdateRequest;
@@ -68,6 +69,27 @@ public class ProfileService {
 
         profile.updateProfileValuePicks(allProfileValues);
         profile.updateProfileValueTalks(allProfileTalks);
+
+        return profile;
+    }
+
+    @Transactional
+    public Profile update(Long userId, ProfileUpdateRequest dto) {
+        Profile profile = userService.getUserById(userId).getProfile();
+
+        ProfileBasic profileBasic = dto.toProfileBasic();
+
+        List<ProfileValuePick> allProfileValues = profileValuePickService.createAllProfileValuePicks(
+            profile.getId(), dto.valuePicks());
+
+        List<ProfileValueTalk> allProfileTalks = profileValueTalkService.createAllProfileValues(
+            profile.getId(), dto.valueTalks()
+        );
+
+        profile.updateBasic(profileBasic);
+        profile.updateProfileValuePicks(allProfileValues);
+        profile.updateProfileValueTalks(allProfileTalks);
+        updateProfileStatus(profile);
 
         return profile;
     }

--- a/api/src/main/java/org/yapp/domain/profile/presentation/ProfileController.java
+++ b/api/src/main/java/org/yapp/domain/profile/presentation/ProfileController.java
@@ -32,6 +32,7 @@ import org.yapp.domain.profile.application.ProfileValueTalkSummaryService;
 import org.yapp.domain.profile.presentation.request.ProfileBasicUpdateRequest;
 import org.yapp.domain.profile.presentation.request.ProfileCreateRequest;
 import org.yapp.domain.profile.presentation.request.ProfileTalkSummaryUpdateRequest;
+import org.yapp.domain.profile.presentation.request.ProfileUpdateRequest;
 import org.yapp.domain.profile.presentation.request.ProfileValuePickUpdateRequest;
 import org.yapp.domain.profile.presentation.request.ProfileValueTalkUpdateRequest;
 import org.yapp.domain.profile.presentation.response.ProfileBasicPreviewResponse;
@@ -67,6 +68,19 @@ public class ProfileController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(CommonResponse.createSuccess(oauthLoginResponse));
+    }
+
+    @PutMapping("")
+    @Operation(summary = "반려 프로필 수정", description = "반려 당한 사용자의 프로필을 수정합니다.", tags = {"프로필"})
+    public ResponseEntity<CommonResponse<Void>> updateProfile(
+        @RequestBody @Valid ProfileUpdateRequest request,
+        @AuthenticationPrincipal Long userId) {
+
+        Profile profile = profileService.update(userId, request);
+        profileValueTalkSummaryService.summaryProfileValueTalksSync(profile);
+
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(CommonResponse.createSuccessWithNoContent("프로필 업데이트가 완료되었습니다."));
     }
 
     @GetMapping("/basic")

--- a/api/src/main/java/org/yapp/domain/profile/presentation/request/ProfileCreateRequest.java
+++ b/api/src/main/java/org/yapp/domain/profile/presentation/request/ProfileCreateRequest.java
@@ -11,6 +11,9 @@ import jakarta.validation.constraints.Positive;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import org.yapp.core.domain.profile.ContactType;
+import org.yapp.core.domain.profile.ProfileBasic;
 import org.yapp.domain.profile.presentation.validation.ValidContactType;
 
 public record ProfileCreateRequest(
@@ -43,7 +46,7 @@ public record ProfileCreateRequest(
     String snsActivityLevel,
 
     @Schema(description = "연락처 정보 (키: ContactType, 값: 연락처 정보) - 사용 가능한 키: " +
-        "[KAKAO_TALK_ID(필수), OPEN_CHAT_URL(선택), INSTAGRAM_ID(선택), PHONE_NUMBER(선택)]",
+        "[KAKAO_TALK_ID(선택), OPEN_CHAT_URL(선택), INSTAGRAM_ID(선택), PHONE_NUMBER(선택) 단, 최소 1개 이상]",
         example = "{\"KAKAO_TALK_ID\": \"john_kakao\", \"PHONE_NUMBER\": \"01098765432\"}")
     @ValidContactType
     Map<String, String> contacts,
@@ -59,5 +62,22 @@ public record ProfileCreateRequest(
 
 ) {
 
-
+    public ProfileBasic toProfileBasic() {
+        return ProfileBasic.builder()
+            .nickname(nickname())
+            .description(description())
+            .birthdate(birthdate())
+            .height(height())
+            .job(job())
+            .location(location())
+            .smokingStatus(smokingStatus())
+            .weight(weight())
+            .snsActivityLevel(snsActivityLevel())
+            .contacts(contacts().entrySet().stream().collect(Collectors.toMap(
+                entry -> ContactType.valueOf(entry.getKey()),
+                Map.Entry::getValue
+            )))
+            .imageUrl(imageUrl())
+            .build();
+    }
 }

--- a/api/src/main/java/org/yapp/domain/profile/presentation/request/ProfileUpdateRequest.java
+++ b/api/src/main/java/org/yapp/domain/profile/presentation/request/ProfileUpdateRequest.java
@@ -1,0 +1,83 @@
+package org.yapp.domain.profile.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.yapp.core.domain.profile.ContactType;
+import org.yapp.core.domain.profile.ProfileBasic;
+import org.yapp.domain.profile.presentation.validation.ValidContactType;
+
+public record ProfileUpdateRequest(
+
+    @NotBlank(message = "닉네임은 필수입니다.")
+    String nickname,
+
+    @NotBlank(message = "나를 표햔하는 한 마디는 필수입니다.")
+    String description,
+
+    @Past(message = "생년월일은 현재 날짜보다 과거여야 합니다.")
+    LocalDate birthdate,
+
+    @Positive(message = "키는 0보다 커야 합니다.")
+    Integer height,
+
+    @NotBlank(message = "직업은 필수입니다.")
+    String job,
+
+    @NotBlank(message = "활동 지역은 필수입니다.")
+    String location,
+
+    @Pattern(regexp = "^(흡연|비흡연)$", message = "흡연 여부는 '흡연' 또는 '비흡연'이어야 합니다.")
+    String smokingStatus,
+
+    @Min(value = 1, message = "몸무게는 최소 1kg 이상이어야 합니다.")
+    Integer weight,
+
+    @Pattern(regexp = "^(활동|은둔)$", message = "SNS 활동 수준은 '활동', '은둔' 중 하나여야 합니다.")
+    String snsActivityLevel,
+
+    @Schema(description = "연락처 정보 (키: ContactType, 값: 연락처 정보) - 사용 가능한 키: " +
+        "[KAKAO_TALK_ID(선택), OPEN_CHAT_URL(선택), INSTAGRAM_ID(선택), PHONE_NUMBER(선택) 단, 최소 1개 이상]",
+        example = "{\"KAKAO_TALK_ID\": \"john_kakao\", \"PHONE_NUMBER\": \"01098765432\"}")
+    @ValidContactType
+    Map<String, String> contacts,
+
+    @Pattern(regexp = "^https?://.*", message = "이미지 URL은 유효한 형식이어야 합니다.")
+    String imageUrl,
+
+    @NotEmpty(message = "최소 하나 이상의 가치관 Pick을 선택해야 합니다.")
+    List<@Valid ProfileValuePickCreateRequest> valuePicks,
+
+    @NotEmpty(message = "최소 하나 이상의 가치관 Talk을 작성해야 합니다.")
+    List<@Valid ProfileValueTalkCreateRequest> valueTalks
+
+) {
+
+    public ProfileBasic toProfileBasic() {
+        return ProfileBasic.builder()
+            .nickname(nickname())
+            .description(description())
+            .birthdate(birthdate())
+            .height(height())
+            .job(job())
+            .location(location())
+            .smokingStatus(smokingStatus())
+            .weight(weight())
+            .snsActivityLevel(snsActivityLevel())
+            .contacts(contacts().entrySet().stream().collect(Collectors.toMap(
+                entry -> ContactType.valueOf(entry.getKey()),
+                Map.Entry::getValue
+            )))
+            .imageUrl(imageUrl())
+            .build();
+    }
+}

--- a/api/src/main/java/org/yapp/domain/profile/presentation/validation/ContactTypeValidator.java
+++ b/api/src/main/java/org/yapp/domain/profile/presentation/validation/ContactTypeValidator.java
@@ -17,10 +17,9 @@ public class ContactTypeValidator implements
 
     @Override
     public boolean isValid(Map<String, String> contacts, ConstraintValidatorContext context) {
-        if (contacts == null || contacts.isEmpty() || !contacts.containsKey(
-            ContactType.KAKAO_TALK_ID.name())) {
+        if (contacts == null || contacts.isEmpty()) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate("카카오톡 ID는 필수 값입니다.")
+            context.buildConstraintViolationWithTemplate("연락처는 최소 1개 이상 입력해야합니다.")
                 .addConstraintViolation();
             return false;
         }

--- a/api/src/main/java/org/yapp/domain/user/application/UserService.java
+++ b/api/src/main/java/org/yapp/domain/user/application/UserService.java
@@ -23,83 +23,89 @@ import org.yapp.domain.user.presentation.dto.response.UserRejectHistoryResponse;
 @RequiredArgsConstructor
 public class UserService {
 
-  private final UserRepository userRepository;
-  private final UserRejectHistoryRepository userRejectHistoryRepository;
-  private final UserDeleteReasonRepository userDeleteReasonRepository;
-  private final AuthTokenGenerator authTokenGenerator;
+    private final UserRepository userRepository;
+    private final UserRejectHistoryRepository userRejectHistoryRepository;
+    private final UserDeleteReasonRepository userDeleteReasonRepository;
+    private final AuthTokenGenerator authTokenGenerator;
 
-  /**
-   * Role을 USER로 바꾸고 변경된 토큰을 반환한다.
-   *
-   * @return 액세스토큰과 리프레시 토큰
-   */
-  @Transactional
-  public OauthLoginResponse completeProfileInitialize(Long userId, Profile profile) {
-    User user =
-        userRepository.findById(userId)
-            .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
-    user.setProfile(profile);
-    user.updateUserRole(RoleStatus.PENDING.getStatus());
-    String oauthId = user.getOauthId();
-    AuthToken authToken = authTokenGenerator.generate(userId, oauthId, user.getRole());
-    return new OauthLoginResponse(RoleStatus.PENDING.getStatus(), authToken.accessToken(),
-        authToken.refreshToken());
-  }
-
-  public User getUserById(Long userId) {
-    return userRepository.findById(userId)
-        .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
-  }
-
-  /**
-   * Role을 Register로 바꾸고 변경된 토큰을 반환한다.
-   *
-   * @return 액세스토큰과 리프레시 토큰
-   */
-  @Transactional
-  public OauthLoginResponse registerPhoneNumber(Long userId, String phoneNumber) {
-    User user =
-        userRepository.findById(userId)
-            .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
-    user.updateUserRole(RoleStatus.REGISTER.getStatus());
-    user.initializePhoneNumber(phoneNumber);
-    String oauthId = user.getOauthId();
-    AuthToken authToken = authTokenGenerator.generate(userId, oauthId, user.getRole());
-    return new OauthLoginResponse(RoleStatus.REGISTER.getStatus(), authToken.accessToken(),
-        authToken.refreshToken());
-  }
-
-  @Transactional(readOnly = true)
-  public UserRejectHistoryResponse getUserRejectHistoryLatest(Long userId) {
-    User user = this.getUserById(userId);
-    Profile profile = user.getProfile();
-
-    boolean reasonImage = false;
-    boolean reasonDescription = false;
-
-    UserRejectHistory userRejectHistory = userRejectHistoryRepository.findTopByUserIdOrderByCreatedAtDesc(
-        userId).orElse(null);
-
-    if (userRejectHistory != null) {
-      reasonImage = userRejectHistory.isReasonImage();
-      reasonDescription = userRejectHistory.isReasonDescription();
+    /**
+     * Role을 USER로 바꾸고 변경된 토큰을 반환한다.
+     *
+     * @return 액세스토큰과 리프레시 토큰
+     */
+    @Transactional
+    public OauthLoginResponse completeProfileInitialize(Long userId, Profile profile) {
+        User user =
+            userRepository.findById(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
+        user.setProfile(profile);
+        user.updateUserRole(RoleStatus.PENDING.getStatus());
+        String oauthId = user.getOauthId();
+        AuthToken authToken = authTokenGenerator.generate(userId, oauthId, user.getRole());
+        return new OauthLoginResponse(RoleStatus.PENDING.getStatus(), authToken.accessToken(),
+            authToken.refreshToken());
     }
 
-    return new UserRejectHistoryResponse(
-        profile.getProfileStatus(),
-        reasonImage,
-        reasonDescription
-    );
-  }
+    public User getUserById(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
+    }
 
-  @Transactional
-  public void deleteUser(Long userId, String reason) {
-    userDeleteReasonRepository.save(new UserDeleteReason(userId, reason));
-    userRepository.deleteById(userId);
-  }
+    /**
+     * Role을 Register로 바꾸고 변경된 토큰을 반환한다.
+     *
+     * @return 액세스토큰과 리프레시 토큰
+     */
+    @Transactional
+    public OauthLoginResponse registerPhoneNumber(Long userId, String phoneNumber) {
+        User user =
+            userRepository.findById(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
+        user.updateUserRole(RoleStatus.REGISTER.getStatus());
+        user.initializePhoneNumber(phoneNumber);
+        String oauthId = user.getOauthId();
+        AuthToken authToken = authTokenGenerator.generate(userId, oauthId, user.getRole());
+        return new OauthLoginResponse(RoleStatus.REGISTER.getStatus(), authToken.accessToken(),
+            authToken.refreshToken());
+    }
 
-  public UserBasicInfoResponse getUserBasicInfo(Long userId) {
-    User user = this.getUserById(userId);
-    return new UserBasicInfoResponse(userId, user.getRole());
-  }
+    @Transactional(readOnly = true)
+    public UserRejectHistoryResponse getUserRejectHistoryLatest(Long userId) {
+        User user = this.getUserById(userId);
+        Profile profile = user.getProfile();
+
+        boolean reasonImage = false;
+        boolean reasonDescription = false;
+
+        UserRejectHistory userRejectHistory = userRejectHistoryRepository.findTopByUserIdOrderByCreatedAtDesc(
+            userId).orElse(null);
+
+        if (userRejectHistory != null) {
+            reasonImage = userRejectHistory.isReasonImage();
+            reasonDescription = userRejectHistory.isReasonDescription();
+        }
+
+        return new UserRejectHistoryResponse(
+            profile.getProfileStatus(),
+            reasonImage,
+            reasonDescription
+        );
+    }
+
+    @Transactional
+    public void deleteUser(Long userId, String reason) {
+        userDeleteReasonRepository.save(new UserDeleteReason(userId, reason));
+        userRepository.deleteById(userId);
+    }
+
+    public UserBasicInfoResponse getUserBasicInfo(Long userId) {
+        User user = this.getUserById(userId);
+
+        Profile profile = user.getProfile();
+
+        String profileStatus =
+            profile != null ? profile.getProfileStatus().toString() : null;
+
+        return new UserBasicInfoResponse(userId, user.getRole(), profileStatus);
+    }
 }

--- a/api/src/main/java/org/yapp/domain/user/application/UserService.java
+++ b/api/src/main/java/org/yapp/domain/user/application/UserService.java
@@ -71,9 +71,6 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public UserRejectHistoryResponse getUserRejectHistoryLatest(Long userId) {
-        User user = this.getUserById(userId);
-        Profile profile = user.getProfile();
-
         boolean reasonImage = false;
         boolean reasonDescription = false;
 
@@ -86,7 +83,6 @@ public class UserService {
         }
 
         return new UserRejectHistoryResponse(
-            profile.getProfileStatus(),
             reasonImage,
             reasonDescription
         );

--- a/api/src/main/java/org/yapp/domain/user/presentation/dto/response/UserBasicInfoResponse.java
+++ b/api/src/main/java/org/yapp/domain/user/presentation/dto/response/UserBasicInfoResponse.java
@@ -1,6 +1,6 @@
 package org.yapp.domain.user.presentation.dto.response;
 
 
-public record UserBasicInfoResponse(Long userId, String role) {
+public record UserBasicInfoResponse(Long userId, String role, String profileStatus) {
 
 }

--- a/api/src/main/java/org/yapp/domain/user/presentation/dto/response/UserRejectHistoryResponse.java
+++ b/api/src/main/java/org/yapp/domain/user/presentation/dto/response/UserRejectHistoryResponse.java
@@ -1,8 +1,5 @@
 package org.yapp.domain.user.presentation.dto.response;
 
-import org.yapp.core.domain.profile.ProfileStatus;
-
-public record UserRejectHistoryResponse(ProfileStatus profileStatus, boolean reasonImage,
-                                        boolean reasonValues) {
+public record UserRejectHistoryResponse(boolean reasonImage, boolean reasonValues) {
 
 }

--- a/api/src/main/java/org/yapp/sse/presentation/SseController.java
+++ b/api/src/main/java/org/yapp/sse/presentation/SseController.java
@@ -21,14 +21,14 @@ public class SseController {
 
     private final FluxSsePersonalService ssePersonalService;
 
-    @PreAuthorize(value = "hasRole('USER')")
+    @PreAuthorize(value = "hasAuthority('USER')")
     @GetMapping("/personal/connect")
     @Operation(summary = "SSE 연결", description = "로그인 회원에 대한 이벤트 수신 스트림을 얻습니다", tags = {"SSE"})
     public Flux<ServerSentEvent<Object>> connect(@AuthenticationPrincipal Long userId) {
         return ssePersonalService.connect(userId);
     }
 
-    @PreAuthorize(value = "hasRole('USER')")
+    @PreAuthorize(value = "hasAuthority('USER')")
     @DeleteMapping("/personal/disconnect")
     @Operation(summary = "SSE 연결 해제", description = "로그인 회원의 SSE 연결을 해제합니다", tags = {"SSE"})
     public ResponseEntity<CommonResponse<Void>> disconnect(@AuthenticationPrincipal Long userId) {

--- a/core/domain/src/main/java/org/yapp/core/domain/profile/Profile.java
+++ b/core/domain/src/main/java/org/yapp/core/domain/profile/Profile.java
@@ -54,11 +54,21 @@ public class Profile extends BaseEntity {
     }
 
     public void updateProfileValuePicks(List<ProfileValuePick> profileValuePicks) {
-        this.profileValuePicks = profileValuePicks;
+        if (this.profileValuePicks != null) {
+            this.profileValuePicks.clear();
+            this.profileValuePicks.addAll(profileValuePicks);
+        } else {
+            this.profileValuePicks = profileValuePicks;
+        }
     }
 
     public void updateProfileValueTalks(List<ProfileValueTalk> profileValueTalks) {
-        this.profileValueTalks = profileValueTalks;
+        if (this.profileValueTalks != null) {
+            this.profileValueTalks.clear();
+            this.profileValueTalks.addAll(profileValueTalks);
+        } else {
+            this.profileValueTalks = profileValueTalks;
+        }
     }
 
     public void updateProfileStatus(ProfileStatus profileStatus) {

--- a/infra/s3/src/main/java/org/yapp/infra/s3/application/S3Service.java
+++ b/infra/s3/src/main/java/org/yapp/infra/s3/application/S3Service.java
@@ -3,7 +3,6 @@ package org.yapp.infra.s3.application;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import java.io.IOException;
@@ -38,9 +37,8 @@ public class S3Service {
         objectMetadata.setContentLength(file.getSize());
 
         try {
-            s3Client.putObject(new PutObjectRequest(bucket, fileName, file.getInputStream(),
-                objectMetadata).withCannedAcl(
-                CannedAccessControlList.PublicRead));
+            s3Client.putObject(
+                new PutObjectRequest(bucket, fileName, file.getInputStream(), objectMetadata));
             return s3Client.getUrl(bucket, fileName).toString();
 
         } catch (AmazonServiceException e) {

--- a/infra/s3/src/main/java/org/yapp/infra/s3/config/S3Config.java
+++ b/infra/s3/src/main/java/org/yapp/infra/s3/config/S3Config.java
@@ -2,7 +2,6 @@ package org.yapp.infra.s3.config;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,9 +17,6 @@ public class S3Config {
     @Value("${s3.secret-key}")
     private String secretKey;
 
-    @Value("${s3.endpoint}")
-    private String endpoint;
-
     @Value("${s3.region}")
     private String region;
 
@@ -29,7 +25,7 @@ public class S3Config {
         BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
 
         return AmazonS3ClientBuilder.standard()
-            .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, region))
+            .withRegion(region)
             .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
             .build();
     }


### PR DESCRIPTION
## 🔗 관련 이슈

## ✨ 작업 내용
- SSE 권한 체크 수정 (hasRole -> hasAuthority)
- 사용자 기본 정보 조회 API 응답에서 profileStatus 추가
- 리젝 사유 조회 응답 수정
- 오브젝트 스토리지 변경 (AWS S3 사용)
- 프로필 연락처 검증 로직 수정 (연락처 최소 1개 이상)
- 프로필 반려시 프로필 수정 기능

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항

## 📋 참고 사항
- 오브젝트 스토리지 변경으로 인해, 기존에 설정해주었던 s3 endpoint와 필요없게 되었고, access-key와 secret-key가 변경되었습니다. 
notion에 정리해둔 .yml 파일을 참고해서 찬호님 개발환경에도 반영하시면 될 것 같습니다.
