### PR TITLE
[PC-856] 차단 데이터 조회시 NOT FOUND 에러 해결

### DIFF
--- a/admin/src/main/java/org/yapp/user/application/UserService.java
+++ b/admin/src/main/java/org/yapp/user/application/UserService.java
@@ -36,6 +36,10 @@ public class UserService {
             .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
     }
 
+    public Optional<User> getUserByIdIfExists(Long userId) {
+        return userRepository.findById(userId);
+    }
+
     public User getUserByOauthId(String oauthId) {
         return userRepository.findByOauthId(oauthId)
             .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));

--- a/core/domain/src/main/java/org/yapp/core/domain/fcm/FcmToken.java
+++ b/core/domain/src/main/java/org/yapp/core/domain/fcm/FcmToken.java
@@ -8,28 +8,29 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.yapp.core.domain.BaseEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor
 @Table(name = "fcm_token")
-public class FcmToken {
+public class FcmToken extends BaseEntity {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "id")
-  private Long id;
-  @Column(name = "user_id")
-  private Long userId;
-  @Column(name = "token")
-  private String token;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+    @Column(name = "user_id")
+    private Long userId;
+    @Column(name = "token")
+    private String token;
 
-  public FcmToken(Long userId, String token) {
-    this.userId = userId;
-    this.token = token;
-  }
+    public FcmToken(Long userId, String token) {
+        this.userId = userId;
+        this.token = token;
+    }
 
-  public void updateToken(String token) {
-    this.token = token;
-  }
+    public void updateToken(String token) {
+        this.token = token;
+    }
 }

--- a/core/domain/src/main/java/org/yapp/core/domain/setting/Setting.java
+++ b/core/domain/src/main/java/org/yapp/core/domain/setting/Setting.java
@@ -7,45 +7,46 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.yapp.core.domain.BaseEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor
-public class Setting {
+public class Setting extends BaseEntity {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-  @Column(name = "user_id")
-  private Long userId;
+    @Column(name = "user_id")
+    private Long userId;
 
-  @Column(name = "match_notification")
-  private boolean matchNotification = true;
+    @Column(name = "match_notification")
+    private boolean matchNotification = true;
 
-  @Column(name = "notification")
-  private boolean notification = true;
+    @Column(name = "notification")
+    private boolean notification = true;
 
-  @Column(name = "acquaintance_block")
-  private boolean acquaintanceBlock = true;
+    @Column(name = "acquaintance_block")
+    private boolean acquaintanceBlock = true;
 
-  public Setting(Long userId, boolean matchNotification, boolean notification,
-      boolean acquaintanceBlock) {
-    this.userId = userId;
-    this.matchNotification = matchNotification;
-    this.notification = notification;
-    this.acquaintanceBlock = acquaintanceBlock;
-  }
+    public Setting(Long userId, boolean matchNotification, boolean notification,
+        boolean acquaintanceBlock) {
+        this.userId = userId;
+        this.matchNotification = matchNotification;
+        this.notification = notification;
+        this.acquaintanceBlock = acquaintanceBlock;
+    }
 
-  public void updateMatchNotification(boolean status) {
-    this.matchNotification = status;
-  }
+    public void updateMatchNotification(boolean status) {
+        this.matchNotification = status;
+    }
 
-  public void updateNotification(boolean status) {
-    this.notification = status;
-  }
+    public void updateNotification(boolean status) {
+        this.notification = status;
+    }
 
-  public void updateAcquaintanceBlock(boolean status) {
-    this.acquaintanceBlock = status;
-  }
+    public void updateAcquaintanceBlock(boolean status) {
+        this.acquaintanceBlock = status;
+    }
 }

--- a/core/domain/src/main/java/org/yapp/core/domain/user/UserDeleteReason.java
+++ b/core/domain/src/main/java/org/yapp/core/domain/user/UserDeleteReason.java
@@ -7,18 +7,19 @@ import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.yapp.core.domain.BaseEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "user_delete_reason")
-public class UserDeleteReason {
+public class UserDeleteReason extends BaseEntity {
 
-  @Id
-  @Column(name = "user_id")
-  private Long id;
+    @Id
+    @Column(name = "user_id")
+    private Long id;
 
-  @Column(name = "reason")
-  private String reason;
+    @Column(name = "reason")
+    private String reason;
 }


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-856](https://yapp25app3.atlassian.net/browse/PC-856)

## ✨ 작업 내용
- 어드민 모듈에서 DirectBlock 테이블에 저장되어있는 userId를 못 찾을 경우, "탈퇴한 유저" 임을 전달하는 코드로 수정 
- Setting, FCMToken, UserDeletReason 테이블에 언제 업데이트 되었는지를 추적할 수 있도록 BaseEntity를 상속

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항

## 📋 참고 사항
- 코드 리뷰 시 논의가 필요한 사항이나 배포 관련 주의 사항을 추가합니다.
