### PR TITLE
[PC-900] 유저 정지 기능 구현

### DIFF
--- a/admin/build.gradle
+++ b/admin/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     implementation project(':core:exception')
     implementation project(':core:auth')
     implementation project(':core:notification')
+    implementation project(':infra:redis')
 
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/admin/src/main/java/org/yapp/ban/application/BanModifyingService.java
+++ b/admin/src/main/java/org/yapp/ban/application/BanModifyingService.java
@@ -1,0 +1,18 @@
+package org.yapp.ban.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.yapp.infra.redis.application.RedisService;
+
+@Service
+@RequiredArgsConstructor
+public class BanModifyingService {
+
+  private static final String USER_BLACK_LIST_SET = "user_blacklist";
+
+  private final RedisService redisService;
+
+  public void addUserToBlackList(Long userId) {
+    redisService.addToSet(USER_BLACK_LIST_SET, String.valueOf(userId));
+  }
+}

--- a/admin/src/main/java/org/yapp/ban/application/BanService.java
+++ b/admin/src/main/java/org/yapp/ban/application/BanService.java
@@ -1,0 +1,30 @@
+package org.yapp.ban.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.yapp.core.auth.dao.BannedUserPhoneNumberRepository;
+import org.yapp.core.auth.token.RefreshTokenService;
+import org.yapp.core.domain.user.BannedUserPhoneNumber;
+import org.yapp.core.domain.user.RoleStatus;
+import org.yapp.core.domain.user.User;
+import org.yapp.user.application.UserService;
+
+@Service
+@RequiredArgsConstructor
+public class BanService {
+
+  private final BannedUserPhoneNumberRepository bannedUserPhoneNumberRepository;
+  private final UserService userService;
+  private final RefreshTokenService refreshTokenService;
+  private final BanModifyingService banModifyingService;
+
+  @Transactional
+  public void banUser(Long userId) {
+    User user = userService.getUserById(userId);
+    user.updateUserRole(RoleStatus.BANNED.getStatus());
+    bannedUserPhoneNumberRepository.save(new BannedUserPhoneNumber(user.getPhoneNumber()));
+    refreshTokenService.deleteRefreshToken(userId);
+    banModifyingService.addUserToBlackList(userId);
+  }
+}

--- a/admin/src/main/java/org/yapp/ban/presentation/BanController.java
+++ b/admin/src/main/java/org/yapp/ban/presentation/BanController.java
@@ -1,0 +1,25 @@
+package org.yapp.ban.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.yapp.ban.application.BanService;
+import org.yapp.ban.presentation.dto.request.UserBanRequest;
+import org.yapp.format.CommonResponse;
+
+@RestController
+@RequestMapping("/admin/v1/bans")
+@RequiredArgsConstructor
+public class BanController {
+
+  private final BanService banService;
+
+  @PostMapping("/users")
+  public ResponseEntity<CommonResponse<Void>> banUser(@RequestBody UserBanRequest request) {
+    banService.banUser(request.userId());
+    return ResponseEntity.ok(CommonResponse.createSuccessWithNoContent());
+  }
+}

--- a/admin/src/main/java/org/yapp/ban/presentation/dto/request/UserBanRequest.java
+++ b/admin/src/main/java/org/yapp/ban/presentation/dto/request/UserBanRequest.java
@@ -1,0 +1,7 @@
+package org.yapp.ban.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UserBanRequest(@NotNull Long userId) {
+
+}

--- a/api/src/main/java/org/yapp/domain/auth/application/oauth/service/OauthService.java
+++ b/api/src/main/java/org/yapp/domain/auth/application/oauth/service/OauthService.java
@@ -22,82 +22,87 @@ import org.yapp.domain.user.presentation.dto.request.OauthUserDeleteRequest;
 @RequiredArgsConstructor
 public class OauthService {
 
-    private final OauthProviderResolver oauthProviderResolver;
-    private final UserRepository userRepository;
-    private final UserService userService;
-    private final RefreshTokenService refreshTokenService;
-    private final AuthTokenGenerator authTokenGenerator;
-    private final SettingService settingService;
+  private final OauthProviderResolver oauthProviderResolver;
+  private final UserRepository userRepository;
+  private final UserService userService;
+  private final RefreshTokenService refreshTokenService;
+  private final AuthTokenGenerator authTokenGenerator;
+  private final SettingService settingService;
 
-    public OauthLoginResponse login(OauthLoginRequest request) {
-        OauthProvider oauthProvider = oauthProviderResolver.find(request.getProviderName());
-        String oauthId =
-            request.getProviderName() + oauthProvider.getOAuthProviderUserId(
-                request.getOauthCredential());
+  public OauthLoginResponse login(OauthLoginRequest request) {
+    OauthProvider oauthProvider = oauthProviderResolver.find(request.getProviderName());
+    String oauthId =
+        request.getProviderName() + oauthProvider.getOAuthProviderUserId(
+            request.getOauthCredential());
 
-        //이미 가입된 유저인지 확인하고 가입되어 있지 않으면 회원가입 처리
-        Optional<User> userOptional = userRepository.findByOauthId(oauthId);
-        if (userOptional.isEmpty()) {
-            User newUser = User.builder().oauthId(oauthId).role(RoleStatus.NONE.getStatus())
-                .build();
-            User savedUser = userRepository.save(newUser);
-            Long userId = savedUser.getId();
-            AuthToken token = authTokenGenerator.generate(userId, savedUser.getOauthId(), "NONE");
-            String accessToken = token.accessToken();
-            String refreshToken = token.refreshToken();
-            settingService.createSetting(userId);
-            refreshTokenService.saveRefreshToken(userId, refreshToken);
-            return new OauthLoginResponse(RoleStatus.NONE.getStatus(), accessToken, refreshToken);
-        }
-
-        //이미 가입한 유저인 경우 로그인 처리
-        Long userId = userOptional.get().getId();
-        final User user = userOptional.get();
-
-        AuthToken token = authTokenGenerator.generate(userId, user.getOauthId(), user.getRole());
-        String accessToken = token.accessToken();
-        String refreshToken = token.refreshToken();
-        refreshTokenService.saveRefreshToken(userId, refreshToken);
-
-        //아직 SMS 인증이 완료되지 않음
-        if (user.getRole().equals("NONE")) {
-            return new OauthLoginResponse(RoleStatus.NONE.getStatus(), accessToken, refreshToken);
-        }
-
-        // SMS 인증은 완료되었으나, 프로필 등록을 안함
-        if (user.getRole().equals("REGISTER")) {
-            return new OauthLoginResponse(RoleStatus.REGISTER.getStatus(), accessToken,
-                refreshToken);
-        }
-
-        //프로필 등록은 했지만, 심사중
-        if (user.getRole().equals("PENDING")) {
-            return new OauthLoginResponse(RoleStatus.PENDING.getStatus(), accessToken,
-                refreshToken);
-        }
-
-        // 가입과 프로필 등록까지 완료된 유저
-        return new OauthLoginResponse(user.getRole(), accessToken, refreshToken);
+    //이미 가입된 유저인지 확인하고 가입되어 있지 않으면 회원가입 처리
+    Optional<User> userOptional = userRepository.findByOauthId(oauthId);
+    if (userOptional.isEmpty()) {
+      User newUser = User.builder().oauthId(oauthId).role(RoleStatus.NONE.getStatus())
+          .build();
+      User savedUser = userRepository.save(newUser);
+      Long userId = savedUser.getId();
+      AuthToken token = authTokenGenerator.generate(userId, savedUser.getOauthId(), "NONE");
+      String accessToken = token.accessToken();
+      String refreshToken = token.refreshToken();
+      settingService.createSetting(userId);
+      refreshTokenService.saveRefreshToken(userId, refreshToken);
+      return new OauthLoginResponse(RoleStatus.NONE.getStatus(), accessToken, refreshToken);
     }
 
-    @Transactional
-    public void withdraw(OauthUserDeleteRequest request, Long userId) {
-        userService.deleteUser(userId, request.getReason());
-        OauthProvider oauthProvider = oauthProviderResolver.find(request.getProviderName());
-        oauthProvider.unlink(request.getOauthCredential());
+    //이미 가입한 유저인 경우 로그인 처리
+    Long userId = userOptional.get().getId();
+    final User user = userOptional.get();
+
+    // 영구정지 당한 유저
+    if (user.getRole().equals(RoleStatus.BANNED.getStatus())) {
+      return new OauthLoginResponse(RoleStatus.BANNED.getStatus(), "", "");
     }
 
-    public OauthLoginResponse tmpTokenGet(Long userId) {
-        //이미 가입된 유저인지 확인하고 가입되어 있지 않으면 회원가입 처리
-        Optional<User> userOptional = userRepository.findById(userId);
+    AuthToken token = authTokenGenerator.generate(userId, user.getOauthId(), user.getRole());
+    String accessToken = token.accessToken();
+    String refreshToken = token.refreshToken();
+    refreshTokenService.saveRefreshToken(userId, refreshToken);
 
-        User user = userOptional.get();
-
-        AuthToken token = authTokenGenerator.generate(userId, user.getOauthId(), user.getRole());
-        String accessToken = token.accessToken();
-        String refreshToken = token.refreshToken();
-        refreshTokenService.saveRefreshToken(userId, refreshToken);
-
-        return new OauthLoginResponse(RoleStatus.NONE.getStatus(), accessToken, refreshToken);
+    //아직 SMS 인증이 완료되지 않음
+    if (user.getRole().equals("NONE")) {
+      return new OauthLoginResponse(RoleStatus.NONE.getStatus(), accessToken, refreshToken);
     }
+
+    // SMS 인증은 완료되었으나, 프로필 등록을 안함
+    if (user.getRole().equals("REGISTER")) {
+      return new OauthLoginResponse(RoleStatus.REGISTER.getStatus(), accessToken,
+          refreshToken);
+    }
+
+    //프로필 등록은 했지만, 심사중
+    if (user.getRole().equals("PENDING")) {
+      return new OauthLoginResponse(RoleStatus.PENDING.getStatus(), accessToken,
+          refreshToken);
+    }
+
+    // 가입과 프로필 등록까지 완료된 유저
+    return new OauthLoginResponse(user.getRole(), accessToken, refreshToken);
+  }
+
+  @Transactional
+  public void withdraw(OauthUserDeleteRequest request, Long userId) {
+    userService.deleteUser(userId, request.getReason());
+    OauthProvider oauthProvider = oauthProviderResolver.find(request.getProviderName());
+    oauthProvider.unlink(request.getOauthCredential());
+  }
+
+  public OauthLoginResponse tmpTokenGet(Long userId) {
+    //이미 가입된 유저인지 확인하고 가입되어 있지 않으면 회원가입 처리
+    Optional<User> userOptional = userRepository.findById(userId);
+
+    User user = userOptional.get();
+
+    AuthToken token = authTokenGenerator.generate(userId, user.getOauthId(), user.getRole());
+    String accessToken = token.accessToken();
+    String refreshToken = token.refreshToken();
+    refreshTokenService.saveRefreshToken(userId, refreshToken);
+
+    return new OauthLoginResponse(RoleStatus.NONE.getStatus(), accessToken, refreshToken);
+  }
 }

--- a/api/src/main/java/org/yapp/domain/auth/presentation/LoginController.java
+++ b/api/src/main/java/org/yapp/domain/auth/presentation/LoginController.java
@@ -20,6 +20,7 @@ import org.yapp.domain.auth.presentation.dto.request.RefreshTokenRequest;
 import org.yapp.domain.auth.presentation.dto.request.TokenHealthCheckRequest;
 import org.yapp.domain.auth.presentation.dto.response.OauthLoginResponse;
 import org.yapp.domain.auth.presentation.dto.response.RefreshedTokensResponse;
+import org.yapp.domain.user.application.BanCheckingService;
 import org.yapp.format.CommonResponse;
 
 @Controller
@@ -30,6 +31,7 @@ public class LoginController {
   private final OauthService oauthService;
   private final RefreshTokenService refreshTokenService;
   private final TokenHealthCheckService tokenHealthCheckService;
+  private final BanCheckingService banCheckingService;
 
   /**
    * 개발중 소셜 로그인으로 사용자의 accessToken을 가져오기 어렵기 때문에 만든 임시 메서드
@@ -53,6 +55,7 @@ public class LoginController {
   @Operation(summary = "토큰 리프레시", description = "accessToken과 refreshToken을 갱신합니다.", tags = {"로그인"})
   public ResponseEntity<CommonResponse<RefreshedTokensResponse>> refreshToken(
       @RequestBody RefreshTokenRequest request) {
+    banCheckingService.checkBlackListByRefreshToken(request.getRefreshToken());
     RefreshedTokens refreshedTokens = refreshTokenService.getUserRefreshedTokens(
         request.getRefreshToken());
     RefreshedTokensResponse response = new RefreshedTokensResponse(

--- a/api/src/main/java/org/yapp/domain/user/application/BanCheckingService.java
+++ b/api/src/main/java/org/yapp/domain/user/application/BanCheckingService.java
@@ -1,0 +1,28 @@
+package org.yapp.domain.user.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.yapp.core.auth.jwt.JwtUtil;
+import org.yapp.core.exception.ApplicationException;
+import org.yapp.core.exception.error.code.AuthErrorCode;
+import org.yapp.infra.redis.application.RedisService;
+
+@Service
+@RequiredArgsConstructor
+public class BanCheckingService {
+
+  private static final String USER_BLACK_LIST_SET = "user_blacklist";
+
+  private final RedisService redisService;
+  private final JwtUtil jwtUtil;
+
+  public boolean existsInBlackList(Long userId) {
+    return redisService.existsInSet(USER_BLACK_LIST_SET, String.valueOf(userId));
+  }
+
+  public void checkBlackListByRefreshToken(String refreshToken) {
+    if (existsInBlackList(jwtUtil.getUserId(refreshToken))) {
+      throw new ApplicationException(AuthErrorCode.PERMANENTLY_BANNED);
+    }
+  }
+}

--- a/api/src/main/java/org/yapp/domain/user/application/UserService.java
+++ b/api/src/main/java/org/yapp/domain/user/application/UserService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.yapp.core.auth.AuthToken;
 import org.yapp.core.auth.AuthTokenGenerator;
+import org.yapp.core.auth.dao.BannedUserPhoneNumberRepository;
 import org.yapp.core.domain.fcm.FcmToken;
 import org.yapp.core.domain.profile.Profile;
 import org.yapp.core.domain.user.RoleStatus;
@@ -28,129 +29,135 @@ import org.yapp.domain.user.presentation.dto.response.UserRejectHistoryResponse;
 @RequiredArgsConstructor
 public class UserService {
 
-    private final UserRepository userRepository;
-    private final UserRejectHistoryRepository userRejectHistoryRepository;
-    private final UserDeleteReasonRepository userDeleteReasonRepository;
-    private final AuthTokenGenerator authTokenGenerator;
-    private final FcmTokenRepository fcmTokenRepository;
+  private final UserRepository userRepository;
+  private final UserRejectHistoryRepository userRejectHistoryRepository;
+  private final UserDeleteReasonRepository userDeleteReasonRepository;
+  private final AuthTokenGenerator authTokenGenerator;
+  private final FcmTokenRepository fcmTokenRepository;
+  private final BannedUserPhoneNumberRepository bannedUserPhoneNumberRepository;
 
-    /**
-     * Role을 USER로 바꾸고 변경된 토큰을 반환한다.
-     *
-     * @return 액세스토큰과 리프레시 토큰
-     */
-    @Transactional
-    public OauthLoginResponse completeProfileInitialize(Long userId, Profile profile) {
-        User user =
-            userRepository.findById(userId)
-                .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
-        user.setProfile(profile);
-        user.updateUserRole(RoleStatus.PENDING.getStatus());
-        String oauthId = user.getOauthId();
-        AuthToken authToken = authTokenGenerator.generate(userId, oauthId, user.getRole());
-        return new OauthLoginResponse(RoleStatus.PENDING.getStatus(), authToken.accessToken(),
-            authToken.refreshToken());
-    }
-
-    public User getUserById(Long userId) {
-        return userRepository.findById(userId)
+  /**
+   * Role을 USER로 바꾸고 변경된 토큰을 반환한다.
+   *
+   * @return 액세스토큰과 리프레시 토큰
+   */
+  @Transactional
+  public OauthLoginResponse completeProfileInitialize(Long userId, Profile profile) {
+    User user =
+        userRepository.findById(userId)
             .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
+    user.setProfile(profile);
+    user.updateUserRole(RoleStatus.PENDING.getStatus());
+    String oauthId = user.getOauthId();
+    AuthToken authToken = authTokenGenerator.generate(userId, oauthId, user.getRole());
+    return new OauthLoginResponse(RoleStatus.PENDING.getStatus(), authToken.accessToken(),
+        authToken.refreshToken());
+  }
+
+  public User getUserById(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
+  }
+
+  /**
+   * Role을 Register로 바꾸고 변경된 토큰을 반환한다.
+   *
+   * @return 액세스토큰과 리프레시 토큰
+   */
+  @Transactional
+  public SmsVerifyResponse registerPhoneNumber(Long userId, String phoneNumber) {
+    Optional<User> userOptionalByPhoneNumber = this.getUserByPhoneNumber(phoneNumber);
+
+    // 이미 가입한 유저
+    if (userOptionalByPhoneNumber.isPresent()) {
+      String userOauthProvider = this.getUserOauthProvider(
+          userOptionalByPhoneNumber.get().getOauthId());
+
+      return new SmsVerifyResponse(null, null, null, true, userOauthProvider);
     }
 
-    /**
-     * Role을 Register로 바꾸고 변경된 토큰을 반환한다.
-     *
-     * @return 액세스토큰과 리프레시 토큰
-     */
-    @Transactional
-    public SmsVerifyResponse registerPhoneNumber(Long userId, String phoneNumber) {
-        Optional<User> userOptionalByPhoneNumber = this.getUserByPhoneNumber(phoneNumber);
-
-        // 이미 가입한 유저
-        if (userOptionalByPhoneNumber.isPresent()) {
-            String userOauthProvider = this.getUserOauthProvider(
-                userOptionalByPhoneNumber.get().getOauthId());
-
-            return new SmsVerifyResponse(null, null, null, true, userOauthProvider);
-        }
-
-        User user =
-            userRepository.findById(userId)
-                .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
-
-        user.updateUserRole(RoleStatus.REGISTER.getStatus());
-        user.initializePhoneNumber(phoneNumber);
-        String oauthId = user.getOauthId();
-        AuthToken authToken = authTokenGenerator.generate(userId, oauthId, user.getRole());
-        return new SmsVerifyResponse(RoleStatus.REGISTER.getStatus(), authToken.accessToken(),
-            authToken.refreshToken(), false, null);
+    // 정지된 유저가 기존 계정 삭제하고 다시 가입하려고 할 때 방지
+    if (bannedUserPhoneNumberRepository.findById(phoneNumber).isPresent()) {
+      return new SmsVerifyResponse("BANNED", null, null, false, null);
     }
 
-    @Transactional(readOnly = true)
-    public UserRejectHistoryResponse getUserRejectHistoryLatest(Long userId) {
-        boolean reasonImage = false;
-        boolean reasonDescription = false;
+    User user =
+        userRepository.findById(userId)
+            .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
 
-        UserRejectHistory userRejectHistory = userRejectHistoryRepository.findTopByUserIdOrderByCreatedAtDesc(
-            userId).orElse(null);
+    user.updateUserRole(RoleStatus.REGISTER.getStatus());
+    user.initializePhoneNumber(phoneNumber);
+    String oauthId = user.getOauthId();
+    AuthToken authToken = authTokenGenerator.generate(userId, oauthId, user.getRole());
+    return new SmsVerifyResponse(RoleStatus.REGISTER.getStatus(), authToken.accessToken(),
+        authToken.refreshToken(), false, null);
+  }
 
-        if (userRejectHistory != null) {
-            reasonImage = userRejectHistory.isReasonImage();
-            reasonDescription = userRejectHistory.isReasonDescription();
-        }
+  @Transactional(readOnly = true)
+  public UserRejectHistoryResponse getUserRejectHistoryLatest(Long userId) {
+    boolean reasonImage = false;
+    boolean reasonDescription = false;
 
-        return new UserRejectHistoryResponse(
-            reasonImage,
-            reasonDescription
-        );
+    UserRejectHistory userRejectHistory = userRejectHistoryRepository.findTopByUserIdOrderByCreatedAtDesc(
+        userId).orElse(null);
+
+    if (userRejectHistory != null) {
+      reasonImage = userRejectHistory.isReasonImage();
+      reasonDescription = userRejectHistory.isReasonDescription();
     }
 
-    @Transactional
-    public void deleteUser(Long userId, String reason) {
-        userDeleteReasonRepository.save(new UserDeleteReason(userId, reason));
-        userRepository.deleteById(userId);
+    return new UserRejectHistoryResponse(
+        reasonImage,
+        reasonDescription
+    );
+  }
+
+  @Transactional
+  public void deleteUser(Long userId, String reason) {
+    userDeleteReasonRepository.save(new UserDeleteReason(userId, reason));
+    userRepository.deleteById(userId);
+  }
+
+  public UserBasicInfoResponse getUserBasicInfo(Long userId) {
+    User user = this.getUserById(userId);
+
+    Profile profile = user.getProfile();
+    String profileStatus =
+        profile != null ? profile.getProfileStatus().toString() : null;
+
+    return new UserBasicInfoResponse(userId, user.getRole(), profileStatus);
+  }
+
+  @Transactional
+  public void saveFcmToken(Long userId, FcmTokenSaveRequest request) {
+    Optional<FcmToken> fcmTokenOptional = fcmTokenRepository.findByUserId(userId);
+    if (fcmTokenOptional.isPresent()) {
+      FcmToken fcmToken = fcmTokenOptional.get();
+      fcmToken.updateToken(request.getToken());
+    } else {
+      FcmToken fcmToken = new FcmToken(userId, request.getToken());
+      fcmTokenRepository.save(fcmToken);
     }
+  }
 
-    public UserBasicInfoResponse getUserBasicInfo(Long userId) {
-        User user = this.getUserById(userId);
+  @Transactional
+  public void deleteFcmToken(Long userId) {
+    fcmTokenRepository.deleteByUserId(userId);
+  }
 
-        Profile profile = user.getProfile();
-        String profileStatus =
-            profile != null ? profile.getProfileStatus().toString() : null;
+  public Optional<User> getUserByPhoneNumber(String phoneNumber) {
+    return userRepository.findByPhoneNumber(phoneNumber);
+  }
 
-        return new UserBasicInfoResponse(userId, user.getRole(), profileStatus);
+  public String getUserOauthProvider(String oauthId) {
+    if (oauthId.startsWith("kakao")) {
+      return "kakao";
+    } else if (oauthId.startsWith("apple")) {
+      return "apple";
+    } else if (oauthId.startsWith("google")) {
+      return "google";
+    } else {
+      throw new ApplicationException(UserErrorCode.INVALID_OAUTH_PROVIDER);
     }
-
-    @Transactional
-    public void saveFcmToken(Long userId, FcmTokenSaveRequest request) {
-        Optional<FcmToken> fcmTokenOptional = fcmTokenRepository.findByUserId(userId);
-        if (fcmTokenOptional.isPresent()) {
-            FcmToken fcmToken = fcmTokenOptional.get();
-            fcmToken.updateToken(request.getToken());
-        } else {
-            FcmToken fcmToken = new FcmToken(userId, request.getToken());
-            fcmTokenRepository.save(fcmToken);
-        }
-    }
-
-    @Transactional
-    public void deleteFcmToken(Long userId) {
-        fcmTokenRepository.deleteByUserId(userId);
-    }
-
-    public Optional<User> getUserByPhoneNumber(String phoneNumber) {
-        return userRepository.findByPhoneNumber(phoneNumber);
-    }
-
-    public String getUserOauthProvider(String oauthId) {
-        if (oauthId.startsWith("kakao")) {
-            return "kakao";
-        } else if (oauthId.startsWith("apple")) {
-            return "apple";
-        } else if (oauthId.startsWith("google")) {
-            return "google";
-        } else {
-            throw new ApplicationException(UserErrorCode.INVALID_OAUTH_PROVIDER);
-        }
-    }
+  }
 }

--- a/api/src/main/java/org/yapp/global/config/InterceptorConfig.java
+++ b/api/src/main/java/org/yapp/global/config/InterceptorConfig.java
@@ -1,0 +1,20 @@
+package org.yapp.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.yapp.global.interceptor.BanCheckingInterceptor;
+
+@Configuration
+@RequiredArgsConstructor
+public class InterceptorConfig implements WebMvcConfigurer {
+
+  private final BanCheckingInterceptor banCheckingInterceptor;
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(banCheckingInterceptor)
+        .addPathPatterns("/api/**");
+  }
+}

--- a/api/src/main/java/org/yapp/global/interceptor/BanCheckingInterceptor.java
+++ b/api/src/main/java/org/yapp/global/interceptor/BanCheckingInterceptor.java
@@ -1,0 +1,34 @@
+package org.yapp.global.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.yapp.core.exception.ApplicationException;
+import org.yapp.core.exception.error.code.AuthErrorCode;
+import org.yapp.domain.user.application.BanCheckingService;
+
+@Component
+@RequiredArgsConstructor
+public class BanCheckingInterceptor implements HandlerInterceptor {
+
+  private final BanCheckingService banCheckingService;
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+      throws Exception {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    // 블랙리스트에 유저 ID 존재하면 인터셉터 통과 못함
+    if (!(authentication instanceof AnonymousAuthenticationToken)) {
+      Long userId = (Long) authentication.getPrincipal();
+      if (banCheckingService.existsInBlackList(userId)) {
+        throw new ApplicationException(AuthErrorCode.PERMANENTLY_BANNED);
+      }
+    }
+    return true;
+  }
+}

--- a/core/auth/src/main/java/org/yapp/core/auth/dao/BannedUserPhoneNumberRepository.java
+++ b/core/auth/src/main/java/org/yapp/core/auth/dao/BannedUserPhoneNumberRepository.java
@@ -1,0 +1,9 @@
+package org.yapp.core.auth.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.yapp.core.domain.user.BannedUserPhoneNumber;
+
+public interface BannedUserPhoneNumberRepository extends
+    JpaRepository<BannedUserPhoneNumber, String> {
+
+}

--- a/core/domain/src/main/java/org/yapp/core/domain/user/BannedUserPhoneNumber.java
+++ b/core/domain/src/main/java/org/yapp/core/domain/user/BannedUserPhoneNumber.java
@@ -1,0 +1,22 @@
+package org.yapp.core.domain.user;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.yapp.core.domain.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "black_list_phone")
+public class BannedUserPhoneNumber extends BaseEntity {
+
+  @Id
+  @Column(name = "phone_number")
+  private String phoneNumber;
+}

--- a/core/domain/src/main/java/org/yapp/core/domain/user/RoleStatus.java
+++ b/core/domain/src/main/java/org/yapp/core/domain/user/RoleStatus.java
@@ -5,14 +5,15 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public enum RoleStatus {
-    NONE("NONE"),
-    REGISTER("REGISTER"),
-    PENDING("PENDING"),
-    USER("USER");
-    private String status;
+  NONE("NONE"),
+  REGISTER("REGISTER"),
+  PENDING("PENDING"),
+  BANNED("BANNED"),
+  USER("USER");
+  private String status;
 
-    @JsonValue
-    public String getStatus() {
-        return status;
-    }
+  @JsonValue
+  public String getStatus() {
+    return status;
+  }
 }

--- a/core/exception/src/main/java/org/yapp/core/exception/error/code/AuthErrorCode.java
+++ b/core/exception/src/main/java/org/yapp/core/exception/error/code/AuthErrorCode.java
@@ -12,8 +12,8 @@ public enum AuthErrorCode implements ErrorCode {
   OAUTH_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "OAuth ID를 찾을 수 없습니다."),
   ID_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "ID 토큰을 찾을 수 없습니다."),
   EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
-  INVALID_TOKEN_CATEGORY(HttpStatus.UNAUTHORIZED, "토큰의 카테고리가 액세스 토큰이 아닙니다.");
-
+  INVALID_TOKEN_CATEGORY(HttpStatus.UNAUTHORIZED, "토큰의 카테고리가 액세스 토큰이 아닙니다."),
+  PERMANENTLY_BANNED(HttpStatus.UNAUTHORIZED, "영구 정지당한 유저입니다");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/infra/redis/src/main/java/org/yapp/infra/redis/application/RedisService.java
+++ b/infra/redis/src/main/java/org/yapp/infra/redis/application/RedisService.java
@@ -106,4 +106,12 @@ public class RedisService {
     ListOperations<String, String> listOps = redisTemplate.opsForList();
     return listOps.leftPop(key);
   }
+
+  public void addToSet(String key, String value) {
+    redisTemplate.opsForSet().add(key, value);
+  }
+
+  public boolean existsInSet(String key, String value) {
+    return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(key, value));
+  }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-900]
## ✨ 작업 내용
- 유저 정지 기능과 어드민 API 구현
- 유저 정지 여부 판단 인터셉터 추가
- 정지된 유저의 재가입 방지로직 추가
- 정지 유저의 리프레시 방지 로직 추가
## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항

## 📋 참고 사항


[PC-900]: https://yapp25app3.atlassian.net/browse/PC-900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ