### PR TITLE
[PC-921] SMS 인증코드 버그 픽스 및 IOS 직렬화 이슈 대응

### DIFF
--- a/api/src/main/java/org/yapp/domain/auth/application/authorization/SmsAuthService.java
+++ b/api/src/main/java/org/yapp/domain/auth/application/authorization/SmsAuthService.java
@@ -15,43 +15,43 @@ import org.yapp.infra.redis.application.RedisService;
 @RequiredArgsConstructor
 public class SmsAuthService {
 
-    private static final long AUTH_CODE_EXPIRE_TIME = 300000;
-    private static final String AUTH_CODE_KEY_PREFIX = "authcode:";
-    private static final String AUTH_CODE_FORMAT = "[PIECE] 인증 번호는 %06d 입니다.";
-    private final AuthCodeGenerator authCodeGenerator;
-    private final SmsSenderService smsSenderService;
-    private final RedisService redisService;
+  private static final long AUTH_CODE_EXPIRE_TIME = 300000;
+  private static final String AUTH_CODE_KEY_PREFIX = "authcode:";
+  private static final String AUTH_CODE_INNER_FORMAT = "%06d";
+  private static final String AUTH_CODE_FORMAT = "[PIECE] 인증 번호는 %06d 입니다.";
+  private final AuthCodeGenerator authCodeGenerator;
+  private final SmsSenderService smsSenderService;
+  private final RedisService redisService;
 
-    /**
-     * 인증번호 전송
-     *
-     * @param phoneNumber 인증 번호를 받을 핸드폰 번호
-     */
-    public SmsAuthResponse sendAuthCodeTo(String phoneNumber) {
+  /**
+   * 인증번호 전송
+   *
+   * @param phoneNumber 인증 번호를 받을 핸드폰 번호
+   */
+  public SmsAuthResponse sendAuthCodeTo(String phoneNumber) {
 
-        int authCode = authCodeGenerator.generate();
-        redisService.setKeyWithExpiration(AUTH_CODE_KEY_PREFIX + phoneNumber,
-            String.valueOf(authCode),
-            AUTH_CODE_EXPIRE_TIME);
-        String authCodeMessage = String.format(AUTH_CODE_FORMAT, authCode);
-        smsSenderService.sendSMS(phoneNumber, authCodeMessage);
-        return new SmsAuthResponse(phoneNumber);
+    int authCode = authCodeGenerator.generate();
+    redisService.setKeyWithExpiration(AUTH_CODE_KEY_PREFIX + phoneNumber,
+        String.format(AUTH_CODE_INNER_FORMAT, authCode), AUTH_CODE_EXPIRE_TIME);
+    String authCodeMessage = String.format(AUTH_CODE_FORMAT, authCode);
+    smsSenderService.sendSMS(phoneNumber, authCodeMessage);
+    return new SmsAuthResponse(phoneNumber);
+  }
+
+  /**
+   * 인증번호 인증
+   *
+   * @param phoneNumber 핸드폰번호
+   * @param code        인증 번호
+   * @return 인증번호 일치 여부
+   */
+  public void verifySmsAuthCode(String phoneNumber, String code) {
+    String expectedCode = redisService.getValue(AUTH_CODE_KEY_PREFIX + phoneNumber);
+    if (expectedCode == null) {
+      throw new ApplicationException(SmsAuthErrorCode.CODE_NOT_EXIST);
     }
-
-    /**
-     * 인증번호 인증
-     *
-     * @param phoneNumber 핸드폰번호
-     * @param code        인증 번호
-     * @return 인증번호 일치 여부
-     */
-    public void verifySmsAuthCode(String phoneNumber, String code) {
-        String expectedCode = redisService.getValue(AUTH_CODE_KEY_PREFIX + phoneNumber);
-        if (expectedCode == null) {
-            throw new ApplicationException(SmsAuthErrorCode.CODE_NOT_EXIST);
-        }
-        if (!expectedCode.equals(code)) {
-            throw new ApplicationException(SmsAuthErrorCode.CODE_NOT_CORRECT);
-        }
+    if (!expectedCode.equals(code)) {
+      throw new ApplicationException(SmsAuthErrorCode.CODE_NOT_CORRECT);
     }
+  }
 }

--- a/api/src/main/java/org/yapp/domain/setting/dto/response/BlockContactSyncTimeResponse.java
+++ b/api/src/main/java/org/yapp/domain/setting/dto/response/BlockContactSyncTimeResponse.java
@@ -1,14 +1,15 @@
 package org.yapp.domain.setting.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.yapp.domain.setting.dto.serializer.BlockContactSyncTimeResponseSerializer;
 
 @Getter
 @AllArgsConstructor
 public class BlockContactSyncTimeResponse {
 
-  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+  @JsonSerialize(using = BlockContactSyncTimeResponseSerializer.class)
   private LocalDateTime syncTime;
 }

--- a/api/src/main/java/org/yapp/domain/setting/dto/serializer/BlockContactSyncTimeResponseSerializer.java
+++ b/api/src/main/java/org/yapp/domain/setting/dto/serializer/BlockContactSyncTimeResponseSerializer.java
@@ -1,0 +1,20 @@
+package org.yapp.domain.setting.dto.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class BlockContactSyncTimeResponseSerializer extends JsonSerializer<LocalDateTime> {
+
+  private static final DateTimeFormatter FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+
+  @Override
+  public void serialize(LocalDateTime localDateTime, JsonGenerator jsonGenerator,
+      SerializerProvider serializerProvider) throws IOException {
+    jsonGenerator.writeString(localDateTime.format(FORMATTER) + "Z");
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-921]
## ✨ 작업 내용
- SMS 인증코드 자리수 관련 문제 해결
- 연락처 동기화 시간 관련 IOS직렬화 이슈 대응 위해 커스텀 JSON Serializer 적용
## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항

## 📋 참고 사항
- 코드 리뷰 시 논의가 필요한 사항이나 배포 관련 주의 사항을 추가합니다.


[PC-907]: https://yapp25app3.atlassian.net/browse/PC-907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PC-921]: https://yapp25app3.atlassian.net/browse/PC-921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ