### PR TITLE
[PC-921] AuthCodeGenerator 에서 String을 반환하도록 변경

### DIFF
--- a/api/src/main/java/org/yapp/domain/auth/application/authorization/AuthCodeGenerator.java
+++ b/api/src/main/java/org/yapp/domain/auth/application/authorization/AuthCodeGenerator.java
@@ -1,14 +1,16 @@
 package org.yapp.domain.auth.application.authorization;
 
-import org.springframework.stereotype.Service;
-
 import java.security.SecureRandom;
+import org.springframework.stereotype.Service;
 
 /**
  * 랜덤 인증번호 생성기
  */
 @Service
 public class AuthCodeGenerator {
+
+  private static final String AUTH_CODE_FORMAT = "%06d";
+
   private final SecureRandom secureRandom = new SecureRandom();
 
   /**
@@ -16,7 +18,8 @@ public class AuthCodeGenerator {
    *
    * @return 6자리 난수
    */
-  public int generate() {
-    return secureRandom.nextInt(1000000);
+  public String generate() {
+    int randomValue = secureRandom.nextInt(1000000);
+    return String.format(AUTH_CODE_FORMAT, randomValue);
   }
 }

--- a/api/src/main/java/org/yapp/domain/auth/application/authorization/SmsAuthService.java
+++ b/api/src/main/java/org/yapp/domain/auth/application/authorization/SmsAuthService.java
@@ -17,8 +17,7 @@ public class SmsAuthService {
 
   private static final long AUTH_CODE_EXPIRE_TIME = 300000;
   private static final String AUTH_CODE_KEY_PREFIX = "authcode:";
-  private static final String AUTH_CODE_INNER_FORMAT = "%06d";
-  private static final String AUTH_CODE_FORMAT = "[PIECE] 인증 번호는 %06d 입니다.";
+  private static final String AUTH_CODE_FORMAT = "[PIECE] 인증 번호는 %s 입니다.";
   private final AuthCodeGenerator authCodeGenerator;
   private final SmsSenderService smsSenderService;
   private final RedisService redisService;
@@ -30,9 +29,9 @@ public class SmsAuthService {
    */
   public SmsAuthResponse sendAuthCodeTo(String phoneNumber) {
 
-    int authCode = authCodeGenerator.generate();
-    redisService.setKeyWithExpiration(AUTH_CODE_KEY_PREFIX + phoneNumber,
-        String.format(AUTH_CODE_INNER_FORMAT, authCode), AUTH_CODE_EXPIRE_TIME);
+    String authCode = authCodeGenerator.generate();
+    redisService.setKeyWithExpiration(AUTH_CODE_KEY_PREFIX + phoneNumber, authCode,
+        AUTH_CODE_EXPIRE_TIME);
     String authCodeMessage = String.format(AUTH_CODE_FORMAT, authCode);
     smsSenderService.sendSMS(phoneNumber, authCodeMessage);
     return new SmsAuthResponse(phoneNumber);

--- a/api/src/test/java/org/yapp/domain/auth/application/authorization/AuthCodeGeneratorTest.java
+++ b/api/src/test/java/org/yapp/domain/auth/application/authorization/AuthCodeGeneratorTest.java
@@ -1,9 +1,9 @@
 package org.yapp.domain.auth.application.authorization;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class AuthCodeGeneratorTest {
 
@@ -14,7 +14,7 @@ class AuthCodeGeneratorTest {
     AuthCodeGenerator authCodeGenerator = new AuthCodeGenerator();
 
     //when
-    int authCode = authCodeGenerator.generate();
+    int authCode = Integer.parseInt(authCodeGenerator.generate());
 
     //then
     assertThat(authCode).isLessThanOrEqualTo(999999).isGreaterThanOrEqualTo(1);

--- a/api/src/test/java/org/yapp/domain/auth/application/authorization/SmsAuthServiceTest.java
+++ b/api/src/test/java/org/yapp/domain/auth/application/authorization/SmsAuthServiceTest.java
@@ -18,40 +18,40 @@ import org.yapp.infra.redis.application.RedisService;
 @ExtendWith(MockitoExtension.class)
 class SmsAuthServiceTest {
 
-    private SmsAuthService smsAuthService;
+  private SmsAuthService smsAuthService;
 
-    @Mock
-    private AuthCodeGenerator authCodeGenerator;
+  @Mock
+  private AuthCodeGenerator authCodeGenerator;
 
-    @Mock
-    private SmsSenderService smsSenderService;
+  @Mock
+  private SmsSenderService smsSenderService;
 
-    @Mock
-    private RedisService redisService;
+  @Mock
+  private RedisService redisService;
 
-    @BeforeEach
-    void setUp() {
-        smsAuthService = new SmsAuthService(authCodeGenerator, smsSenderService, redisService);
-    }
+  @BeforeEach
+  void setUp() {
+    smsAuthService = new SmsAuthService(authCodeGenerator, smsSenderService, redisService);
+  }
 
-    @Test
-    @DisplayName("인증코드를 SMS 서비스로 전송한다.")
-    void shouldSendAuthCodeToPhoneNumber() {
-        // Given
-        String phoneNumber = "01012345678";
-        int mockAuthCode = 123456;
-        when(authCodeGenerator.generate()).thenReturn(mockAuthCode);
+  @Test
+  @DisplayName("인증코드를 SMS 서비스로 전송한다.")
+  void shouldSendAuthCodeToPhoneNumber() {
+    // Given
+    String phoneNumber = "01012345678";
+    String mockAuthCode = "123456";
+    when(authCodeGenerator.generate()).thenReturn(mockAuthCode);
 
-        // When
-        smsAuthService.sendAuthCodeTo(phoneNumber);
+    // When
+    smsAuthService.sendAuthCodeTo(phoneNumber);
 
-        // Then
-        ArgumentCaptor<String> phoneCaptor = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+    // Then
+    ArgumentCaptor<String> phoneCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
 
-        verify(smsSenderService, times(1)).sendSMS(phoneCaptor.capture(), messageCaptor.capture());
+    verify(smsSenderService, times(1)).sendSMS(phoneCaptor.capture(), messageCaptor.capture());
 
-        assertThat(phoneCaptor.getValue()).isEqualTo(phoneNumber);
-        assertThat(messageCaptor.getValue()).isEqualTo("[PIECE] 인증 번호는 123456 입니다.");
-    }
+    assertThat(phoneCaptor.getValue()).isEqualTo(phoneNumber);
+    assertThat(messageCaptor.getValue()).isEqualTo("[PIECE] 인증 번호는 123456 입니다.");
+  }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-921]
## ✨ 작업 내용
- AuthCodeGenerator 에서 String을 반환하도록 변경한 부분이 누락되어 다시 PR올립니다
## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항

## 📋 참고 사항
- 코드 리뷰 시 논의가 필요한 사항이나 배포 관련 주의 사항을 추가합니다.


[PC-907]: https://yapp25app3.atlassian.net/browse/PC-907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PC-921]: https://yapp25app3.atlassian.net/browse/PC-921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ