### PR TITLE
[PC-876] 수정된 프로필 이미지 심사

### DIFF
--- a/admin/src/main/java/org/yapp/notification/application/AdminNotificationService.java
+++ b/admin/src/main/java/org/yapp/notification/application/AdminNotificationService.java
@@ -11,22 +11,40 @@ import org.yapp.core.notification.dao.FcmTokenRepository;
 @RequiredArgsConstructor
 public class AdminNotificationService {
 
-  private final NotificationService notificationService;
-  private final FcmTokenRepository fcmTokenRepository;
+    private final NotificationService notificationService;
+    private final FcmTokenRepository fcmTokenRepository;
 
-  @Transactional
-  public void sendProfileApprovedNotification(Long userId) {
-    fcmTokenRepository.findByUserId(userId).ifPresent(fcmToken -> {
-      notificationService.sendNotification("fcm", fcmToken.getToken(), userId,
-          NotificationType.PROFILE_APPROVED, "가입이 승인되었어요!", "매일 밤 10시, 설레는 인연을 만나보세요!");
-    });
-  }
+    @Transactional
+    public void sendProfileApprovedNotification(Long userId) {
+        fcmTokenRepository.findByUserId(userId).ifPresent(fcmToken -> {
+            notificationService.sendNotification("fcm", fcmToken.getToken(), userId,
+                NotificationType.PROFILE_APPROVED, "가입이 승인되었어요!", "매일 밤 10시, 설레는 인연을 만나보세요!");
+        });
+    }
 
-  @Transactional
-  public void sendProfileRejectedNotification(Long userId) {
-    fcmTokenRepository.findByUserId(userId).ifPresent(fcmToken -> {
-      notificationService.sendNotification("fcm", fcmToken.getToken(), userId,
-          NotificationType.PROFILE_REJECTED, "프로필이 반려되었어요", "반려 사유를 확인하고 수정해보세요!");
-    });
-  }
+    @Transactional
+    public void sendProfileRejectedNotification(Long userId) {
+        fcmTokenRepository.findByUserId(userId).ifPresent(fcmToken -> {
+            notificationService.sendNotification("fcm", fcmToken.getToken(), userId,
+                NotificationType.PROFILE_REJECTED, "프로필이 반려되었어요", "반려 사유를 확인하고 수정해보세요!");
+        });
+    }
+
+    @Transactional
+    public void sendProfileImageApprovedNotification(Long userId) {
+        fcmTokenRepository.findByUserId(userId).ifPresent(fcmToken -> {
+            notificationService.sendNotification("fcm", fcmToken.getToken(), userId,
+                NotificationType.PROFILE_IMAGE_APPROVED, "프로필 사진이 변경되었어요",
+                "앞으로 새로운 프로필 사진이 적용돼요!");
+        });
+    }
+
+    @Transactional
+    public void sendProfileImageRejectedNotification(Long userId) {
+        fcmTokenRepository.findByUserId(userId).ifPresent(fcmToken -> {
+            notificationService.sendNotification("fcm", fcmToken.getToken(), userId,
+                NotificationType.PROFILE_IMAGE_REJECTED, "프로필 사진 변경이 반려되었어요",
+                "얼굴이 잘 나온 정면 사진으로 다시 등록해주세요!");
+        });
+    }
 }

--- a/admin/src/main/java/org/yapp/profile/application/AdminProfileImageService.java
+++ b/admin/src/main/java/org/yapp/profile/application/AdminProfileImageService.java
@@ -1,5 +1,6 @@
 package org.yapp.profile.application;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -70,5 +71,13 @@ public class AdminProfileImageService {
         } catch (ApplicationException e) {
             log.warn("프로필 이미지 변경 FCM 알림 전송이 실패했습니다.", e);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public ProfileImage getLatestProfileImageByProfileId(Long profileId) {
+        Optional<ProfileImage> optionalProfileImage = profileImageRepository.findTopByProfileIdOrderByCreatedAtDesc(
+            profileId);
+
+        return optionalProfileImage.orElse(null);
     }
 }

--- a/admin/src/main/java/org/yapp/profile/application/AdminProfileImageService.java
+++ b/admin/src/main/java/org/yapp/profile/application/AdminProfileImageService.java
@@ -1,0 +1,74 @@
+package org.yapp.profile.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.yapp.core.domain.profile.Profile;
+import org.yapp.core.domain.profile.ProfileImage;
+import org.yapp.core.domain.user.User;
+import org.yapp.core.exception.ApplicationException;
+import org.yapp.core.exception.error.code.ProfileErrorCode;
+import org.yapp.core.exception.error.code.ProfileImageErrorCode;
+import org.yapp.core.exception.error.code.UserErrorCode;
+import org.yapp.notification.application.AdminNotificationService;
+import org.yapp.profile.dao.ProfileImageRepository;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminProfileImageService {
+
+    private final ProfileImageRepository profileImageRepository;
+    private final AdminNotificationService adminNotificationService;
+
+    @Transactional(readOnly = true)
+    public ProfileImage getByProfileImageId(Long profileImageId) {
+        return profileImageRepository.findById(profileImageId)
+            .orElseThrow(
+                () -> new ApplicationException(ProfileImageErrorCode.PROFILE_IMAGE_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public User getUserByProfileImageId(Long profileImageId) {
+        ProfileImage profileImage = this.getByProfileImageId(profileImageId);
+        Profile profile = profileImage.getProfile();
+
+        if (profile == null) {
+            throw new ApplicationException(ProfileErrorCode.NOTFOUND_PROFILE);
+        }
+
+        User user = profile.getUser();
+        if (user == null) {
+            throw new ApplicationException(UserErrorCode.NOTFOUND_USER);
+        }
+
+        return user;
+    }
+
+    @Transactional
+    public void acceptProfileImage(Long profileImageId) {
+        ProfileImage profileImage = getByProfileImageId(profileImageId);
+        User user = getUserByProfileImageId(profileImageId);
+
+        profileImage.accept();
+        try {
+            adminNotificationService.sendProfileImageApprovedNotification(user.getId());
+        } catch (ApplicationException e) {
+            log.warn("프로필 이미지 변경 FCM 알림 전송이 실패했습니다.", e);
+        }
+    }
+
+    @Transactional
+    public void rejectProfileImage(Long profileImageId) {
+        ProfileImage profileImage = getByProfileImageId(profileImageId);
+        User user = getUserByProfileImageId(profileImageId);
+
+        profileImage.reject();
+        try {
+            adminNotificationService.sendProfileImageRejectedNotification(user.getId());
+        } catch (ApplicationException e) {
+            log.warn("프로필 이미지 변경 FCM 알림 전송이 실패했습니다.", e);
+        }
+    }
+}

--- a/admin/src/main/java/org/yapp/profile/application/AdminProfileService.java
+++ b/admin/src/main/java/org/yapp/profile/application/AdminProfileService.java
@@ -18,41 +18,51 @@ import org.yapp.user.dao.UserRejectHistoryRepository;
 @RequiredArgsConstructor
 public class AdminProfileService {
 
-  private final UserRejectHistoryRepository userRejectHistoryRepository;
-  private final UserService userService;
-  private final AdminNotificationService adminNotificationService;
+    private final UserRejectHistoryRepository userRejectHistoryRepository;
+    private final UserService userService;
+    private final AdminNotificationService adminNotificationService;
+    private final AdminProfileImageService adminProfileImageService;
 
-  @Transactional
-  public void updateProfileStatus(Long userId, boolean reasonImage, boolean reasonDescription) {
-    User user = userService.getUserById(userId);
-    Profile profile = user.getProfile();
+    @Transactional
+    public void updateProfileStatus(Long userId, boolean reasonImage, boolean reasonDescription) {
+        User user = userService.getUserById(userId);
+        Profile profile = user.getProfile();
 
-    if (profile == null) {
-      throw new ApplicationException(ProfileErrorCode.NOTFOUND_PROFILE);
+        if (profile == null) {
+            throw new ApplicationException(ProfileErrorCode.NOTFOUND_PROFILE);
+        }
+
+        if (reasonImage || reasonDescription) {
+            rejectProfile(user.getProfile(), reasonImage, reasonDescription);
+            adminNotificationService.sendProfileRejectedNotification(userId);
+        } else {
+            passProfile(profile);
+            adminNotificationService.sendProfileApprovedNotification(userId);
+        }
     }
 
-    if (reasonImage || reasonDescription) {
-      rejectProfile(user.getProfile(), reasonImage, reasonDescription);
-      adminNotificationService.sendProfileRejectedNotification(userId);
-    } else {
-      passProfile(profile);
-      adminNotificationService.sendProfileApprovedNotification(userId);
+    private void rejectProfile(Profile profile, boolean reasonImage, boolean reasonDescription) {
+        userRejectHistoryRepository.save(UserRejectHistory.builder()
+            .user(profile.getUser())
+            .reasonImage(reasonImage)
+            .reasonDescription(reasonDescription)
+            .build());
+
+        profile.updateProfileStatus(ProfileStatus.REJECTED);
+        profile.getUser().updateUserRole(RoleStatus.PENDING.getStatus());
     }
-  }
 
-  private void rejectProfile(Profile profile, boolean reasonImage, boolean reasonDescription) {
-    userRejectHistoryRepository.save(UserRejectHistory.builder()
-        .user(profile.getUser())
-        .reasonImage(reasonImage)
-        .reasonDescription(reasonDescription)
-        .build());
+    private void passProfile(Profile profile) {
+        profile.updateProfileStatus(ProfileStatus.APPROVED);
+        profile.getUser().updateUserRole(RoleStatus.USER.getStatus());
+    }
 
-    profile.updateProfileStatus(ProfileStatus.REJECTED);
-    profile.getUser().updateUserRole(RoleStatus.PENDING.getStatus());
-  }
-
-  private void passProfile(Profile profile) {
-    profile.updateProfileStatus(ProfileStatus.APPROVED);
-    profile.getUser().updateUserRole(RoleStatus.USER.getStatus());
-  }
+    @Transactional
+    public void updateProfileImageStatus(Long profileImageId, boolean accepted) {
+        if (accepted) {
+            adminProfileImageService.acceptProfileImage(profileImageId);
+        } else {
+            adminProfileImageService.rejectProfileImage(profileImageId);
+        }
+    }
 }

--- a/admin/src/main/java/org/yapp/profile/dao/ProfileImageRepository.java
+++ b/admin/src/main/java/org/yapp/profile/dao/ProfileImageRepository.java
@@ -1,0 +1,18 @@
+package org.yapp.profile.dao;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.yapp.core.domain.profile.ProfileImage;
+import org.yapp.core.domain.profile.ProfileImageStatus;
+
+@Repository
+public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
+
+    List<ProfileImage> findByProfileId(Long profileId);
+
+    List<ProfileImage> findByProfileIdAndStatus(Long profileId, ProfileImageStatus status);
+
+    Optional<ProfileImage> findTopByProfileIdOrderByCreatedAtDesc(Long profileId);
+}

--- a/admin/src/main/java/org/yapp/profile/presentation/ProfileImagesController.java
+++ b/admin/src/main/java/org/yapp/profile/presentation/ProfileImagesController.java
@@ -1,0 +1,28 @@
+package org.yapp.profile.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.yapp.format.CommonResponse;
+import org.yapp.profile.application.AdminProfileService;
+import org.yapp.profile.presentation.request.UpdateProfileImageStatusRequest;
+
+@RestController
+@RequestMapping("/admin/v1/profileImages")
+@RequiredArgsConstructor
+public class ProfileImagesController {
+
+    private final AdminProfileService adminProfileService;
+
+    @PatchMapping("/{profileImageId}")
+    public ResponseEntity<CommonResponse<Void>> updateProfileImageStatus(
+        @PathVariable Long profileImageId,
+        @RequestBody UpdateProfileImageStatusRequest request) {
+        adminProfileService.updateProfileImageStatus(profileImageId, request.accepted());
+        return ResponseEntity.ok(CommonResponse.createSuccess(null));
+    }
+}

--- a/admin/src/main/java/org/yapp/profile/presentation/request/UpdateProfileImageStatusRequest.java
+++ b/admin/src/main/java/org/yapp/profile/presentation/request/UpdateProfileImageStatusRequest.java
@@ -1,0 +1,7 @@
+package org.yapp.profile.presentation.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateProfileImageStatusRequest(@NotNull boolean accepted) {
+
+}

--- a/admin/src/main/java/org/yapp/user/presentation/UserController.java
+++ b/admin/src/main/java/org/yapp/user/presentation/UserController.java
@@ -14,6 +14,7 @@ import org.yapp.format.CommonResponse;
 import org.yapp.format.PageResponse;
 import org.yapp.profile.application.AdminProfileService;
 import org.yapp.user.application.UserService;
+import org.yapp.user.presentation.request.UpdateProfileStatusRequest;
 import org.yapp.user.presentation.response.UserProfileDetailResponses;
 import org.yapp.user.presentation.response.UserProfileValidationResponse;
 
@@ -30,8 +31,9 @@ public class UserController {
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "10") int size) {
 
-        PageResponse<UserProfileValidationResponse> userProfilesWithPagination = userService.getUserProfilesWithPagination(
-            page, size);
+        PageResponse<UserProfileValidationResponse> userProfilesWithPagination = userService
+            .getUserProfilesWithPagination(
+                page, size);
 
         return ResponseEntity.ok(CommonResponse.createSuccess(userProfilesWithPagination));
     }

--- a/admin/src/main/java/org/yapp/user/presentation/UserController.java
+++ b/admin/src/main/java/org/yapp/user/presentation/UserController.java
@@ -16,6 +16,7 @@ import org.yapp.profile.application.AdminProfileService;
 import org.yapp.user.application.UserService;
 import org.yapp.user.presentation.request.UpdateProfileStatusRequest;
 import org.yapp.user.presentation.response.UserProfileDetailResponses;
+import org.yapp.user.presentation.response.UserProfileImageDetailResponse;
 import org.yapp.user.presentation.response.UserProfileValidationResponse;
 
 @RestController()
@@ -44,6 +45,16 @@ public class UserController {
 
         UserProfileDetailResponses userProfileDetails = userService.getUserProfileDetails(userId);
         return ResponseEntity.ok(CommonResponse.createSuccess(userProfileDetails));
+    }
+
+    @GetMapping("/{userId}/profileImage")
+    public ResponseEntity<CommonResponse<UserProfileImageDetailResponse>> getUserProfileImage(
+        @PathVariable Long userId) {
+
+        UserProfileImageDetailResponse userProfileImageDetails = userService.getUserProfileImageDetails(
+            userId);
+
+        return ResponseEntity.ok(CommonResponse.createSuccess(userProfileImageDetails));
     }
 
     @PostMapping("/{userId}/profile")

--- a/admin/src/main/java/org/yapp/user/presentation/request/UpdateProfileStatusRequest.java
+++ b/admin/src/main/java/org/yapp/user/presentation/request/UpdateProfileStatusRequest.java
@@ -1,8 +1,8 @@
-package org.yapp.user.presentation;
+package org.yapp.user.presentation.request;
 
 import jakarta.validation.constraints.NotNull;
 
 public record UpdateProfileStatusRequest(@NotNull boolean rejectImage,
-                                         @NotNull boolean rejectDescription) {
+        @NotNull boolean rejectDescription) {
 
 }

--- a/admin/src/main/java/org/yapp/user/presentation/response/UserProfileImageDetailResponse.java
+++ b/admin/src/main/java/org/yapp/user/presentation/response/UserProfileImageDetailResponse.java
@@ -1,0 +1,19 @@
+package org.yapp.user.presentation.response;
+
+import org.yapp.core.domain.profile.ProfileImage;
+
+public record UserProfileImageDetailResponse(String profileImageUrl,
+                                             UserProfileImageResponse pendingProfileImage) {
+
+    public static UserProfileImageDetailResponse from(ProfileImage profileImage,
+        String profileImageUrl) {
+        if (profileImage == null) {
+            return new UserProfileImageDetailResponse(profileImageUrl, null);
+        }
+
+        UserProfileImageResponse innerResponse = new UserProfileImageResponse(
+            profileImage.getId(), profileImage.getImageUrl(), profileImage.getStatus());
+
+        return new UserProfileImageDetailResponse(profileImageUrl, innerResponse);
+    }
+}

--- a/admin/src/main/java/org/yapp/user/presentation/response/UserProfileImageResponse.java
+++ b/admin/src/main/java/org/yapp/user/presentation/response/UserProfileImageResponse.java
@@ -3,7 +3,7 @@ package org.yapp.user.presentation.response;
 import org.yapp.core.domain.profile.ProfileImageStatus;
 
 record UserProfileImageResponse(Long profileImageId,
-                                String pendingProfileImageUrl,
+                                String profileImageUrl,
                                 ProfileImageStatus profileImageStatus) {
 
 }

--- a/admin/src/main/java/org/yapp/user/presentation/response/UserProfileImageResponse.java
+++ b/admin/src/main/java/org/yapp/user/presentation/response/UserProfileImageResponse.java
@@ -1,0 +1,9 @@
+package org.yapp.user.presentation.response;
+
+import org.yapp.core.domain.profile.ProfileImageStatus;
+
+record UserProfileImageResponse(Long profileImageId,
+                                String pendingProfileImageUrl,
+                                ProfileImageStatus profileImageStatus) {
+
+}

--- a/admin/src/main/java/org/yapp/user/presentation/response/UserProfileValidationResponse.java
+++ b/admin/src/main/java/org/yapp/user/presentation/response/UserProfileValidationResponse.java
@@ -3,17 +3,23 @@ package org.yapp.user.presentation.response;
 import java.time.LocalDate;
 import lombok.Builder;
 import org.yapp.core.domain.profile.Profile;
+import org.yapp.core.domain.profile.ProfileImageStatus;
 import org.yapp.core.domain.user.User;
+
 
 @Builder
 public record UserProfileValidationResponse(Long userId, String description,
                                             String nickname,
                                             String name, LocalDate birthdate, String phoneNumber,
                                             LocalDate joinDate,
-                                            String profileStatus, boolean rejectImage,
+                                            String profileStatus,
+                                            String profileImageStatus,
+                                            boolean rejectImage,
                                             boolean rejectDescription) {
 
-    public static UserProfileValidationResponse from(User user, boolean rejectImage,
+    public static UserProfileValidationResponse from(User user,
+        ProfileImageStatus profileImageStatus,
+        boolean rejectImage,
         boolean rejectDescription) {
         Profile profile = user.getProfile();
 
@@ -26,6 +32,8 @@ public record UserProfileValidationResponse(Long userId, String description,
             .phoneNumber(user.getPhoneNumber() != null ? user.getPhoneNumber() : null)
             .joinDate(user.getCreatedAt() != null ? user.getCreatedAt().toLocalDate() : null)
             .profileStatus(profile != null ? profile.getProfileStatus().getDisplayName() : null)
+            .profileImageStatus(
+                profileImageStatus != null ? profileImageStatus.getDisplayName() : null)
             .rejectImage(rejectImage)
             .rejectDescription(rejectDescription)
             .build();

--- a/api/src/main/java/org/yapp/domain/profile/application/ProfileImageService.java
+++ b/api/src/main/java/org/yapp/domain/profile/application/ProfileImageService.java
@@ -3,24 +3,31 @@ package org.yapp.domain.profile.application;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import org.yapp.core.domain.profile.Profile;
+import org.yapp.core.domain.profile.ProfileImage;
+import org.yapp.core.domain.profile.ProfileImageStatus;
 import org.yapp.core.exception.ApplicationException;
 import org.yapp.core.exception.error.code.ProfileErrorCode;
+import org.yapp.domain.profile.dao.ProfileImageRepository;
 import org.yapp.infra.s3.application.S3Service;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class ProfileImageService {
 
     private final S3Service s3Service;
+    private final ProfileImageRepository profileImageRepository;
     private static final List<String> ALLOWED_MIME_TYPES = List.of("image/jpeg",
-        "image/png", "image/webp");
+            "image/png", "image/webp");
 
     public String uploadProfileImage(MultipartFile file) throws IOException {
-        String uniqueFileName =
-            "profiles/image/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+        String uniqueFileName = "profiles/image/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
 
         String contentType = file.getContentType();
 
@@ -30,4 +37,14 @@ public class ProfileImageService {
 
         return s3Service.upload(file, uniqueFileName);
     }
+
+    @Transactional
+    public ProfileImage create(Long profileId, String imageUrl) {
+        return profileImageRepository.save(ProfileImage.builder()
+                .profile(Profile.builder().id(profileId).build())
+                .imageUrl(imageUrl)
+                .status(ProfileImageStatus.PENDING)
+                .build());
+    }
+
 }

--- a/api/src/main/java/org/yapp/domain/profile/application/ProfileService.java
+++ b/api/src/main/java/org/yapp/domain/profile/application/ProfileService.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.yapp.core.domain.profile.Profile;
@@ -26,8 +26,6 @@ import org.yapp.domain.profile.presentation.request.ProfileValueTalkUpdateReques
 import org.yapp.domain.profile.presentation.request.ProfileValueTalkUpdateRequest.ProfileValueTalkPair;
 import org.yapp.domain.user.application.UserService;
 
-import lombok.RequiredArgsConstructor;
-
 @Service
 @RequiredArgsConstructor
 public class ProfileService {
@@ -43,15 +41,15 @@ public class ProfileService {
         ProfileBasic profileBasic = dto.toProfileBasic();
 
         Profile profile = Profile.builder().profileBasic(profileBasic)
-                .build();
+            .build();
 
         profileRepository.save(profile);
 
         List<ProfileValuePick> allProfileValues = profileValuePickService.createAllProfileValuePicks(
-                profile.getId(), dto.valuePicks());
+            profile.getId(), dto.valuePicks());
 
         List<ProfileValueTalk> allProfileTalks = profileValueTalkService.createAllProfileValues(
-                profile.getId(), dto.valueTalks());
+            profile.getId(), dto.valueTalks());
 
         profile.updateProfileValuePicks(allProfileValues);
         profile.updateProfileValueTalks(allProfileTalks);
@@ -66,10 +64,10 @@ public class ProfileService {
         ProfileBasic profileBasic = dto.toProfileBasic();
 
         List<ProfileValuePick> allProfileValues = profileValuePickService.createAllProfileValuePicks(
-                profile.getId(), dto.valuePicks());
+            profile.getId(), dto.valuePicks());
 
         List<ProfileValueTalk> allProfileTalks = profileValueTalkService.createAllProfileValues(
-                profile.getId(), dto.valueTalks());
+            profile.getId(), dto.valueTalks());
 
         profile.updateBasic(profileBasic);
         profile.updateProfileValuePicks(allProfileValues);
@@ -82,14 +80,14 @@ public class ProfileService {
     @Transactional(readOnly = true)
     public Profile getProfileById(long profileId) {
         return profileRepository.findById(profileId)
-                .orElseThrow(() -> new ApplicationException(ProfileErrorCode.NOTFOUND_PROFILE));
+            .orElseThrow(() -> new ApplicationException(ProfileErrorCode.NOTFOUND_PROFILE));
     }
 
     @Transactional(readOnly = true)
     public List<Profile> getValidProfilesByLocation(String locationName) {
         return profileRepository.findByProfileBasic_LocationAndUser_RoleAndUser_IsAdminIsNull(
-                locationName,
-                RoleStatus.USER.getStatus());
+            locationName,
+            RoleStatus.USER.getStatus());
     }
 
     @Transactional
@@ -100,11 +98,12 @@ public class ProfileService {
 
         profileImageUpdate(profile, newProfileBasic.getImageUrl());
         String oldImageUrl = null;
-        if (profile != null && profile.getProfileBasic() != null) {
+        if (profile.getProfileBasic() != null) {
             oldImageUrl = profile.getProfileBasic().getImageUrl();
         }
 
-        newProfileBasic.setImageUrl(oldImageUrl);
+        profile.updateBasic(newProfileBasic);
+        profile.updateProfileImageUrl(oldImageUrl);
         return profile;
     }
 
@@ -154,11 +153,11 @@ public class ProfileService {
         List<ProfileValueTalk> profileValueTalks = profile.getProfileValueTalks();
 
         HashMap<Long, ProfileValueTalk> profileValueTalkHashMap = profileValueTalks.stream()
-                .collect(Collectors.toMap(
-                        ProfileValueTalk::getId,
-                        profileValueTalk -> profileValueTalk,
-                        (existing, replacement) -> existing,
-                        HashMap::new));
+            .collect(Collectors.toMap(
+                ProfileValueTalk::getId,
+                profileValueTalk -> profileValueTalk,
+                (existing, replacement) -> existing,
+                HashMap::new));
 
         for (ProfileValueTalkPair profileValuePickPair : dto.profileValueTalkUpdateRequests()) {
             final Long profileValueTalkId = profileValuePickPair.profileValueTalkId();
@@ -177,7 +176,7 @@ public class ProfileService {
         ProfileStatus profileStatus = profile.getProfileStatus();
 
         if (ProfileStatus.INCOMPLETE.equals(profileStatus) ||
-                ProfileStatus.REJECTED.equals(profileStatus)) {
+            ProfileStatus.REJECTED.equals(profileStatus)) {
             profile.updateProfileStatus(ProfileStatus.REVISED);
         }
     }

--- a/api/src/main/java/org/yapp/domain/profile/application/ProfileService.java
+++ b/api/src/main/java/org/yapp/domain/profile/application/ProfileService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.yapp.core.domain.profile.Profile;
 import org.yapp.core.domain.profile.ProfileBasic;
+import org.yapp.core.domain.profile.ProfileImageStatus;
 import org.yapp.core.domain.profile.ProfileStatus;
 import org.yapp.core.domain.profile.ProfileValuePick;
 import org.yapp.core.domain.profile.ProfileValueTalk;
@@ -16,6 +17,7 @@ import org.yapp.core.domain.user.RoleStatus;
 import org.yapp.core.domain.user.User;
 import org.yapp.core.exception.ApplicationException;
 import org.yapp.core.exception.error.code.ProfileErrorCode;
+import org.yapp.domain.profile.application.dto.ProfileImageDto;
 import org.yapp.domain.profile.dao.ProfileRepository;
 import org.yapp.domain.profile.presentation.request.ProfileBasicUpdateRequest;
 import org.yapp.domain.profile.presentation.request.ProfileCreateRequest;
@@ -24,6 +26,7 @@ import org.yapp.domain.profile.presentation.request.ProfileValuePickUpdateReques
 import org.yapp.domain.profile.presentation.request.ProfileValuePickUpdateRequest.ProfileValuePickPair;
 import org.yapp.domain.profile.presentation.request.ProfileValueTalkUpdateRequest;
 import org.yapp.domain.profile.presentation.request.ProfileValueTalkUpdateRequest.ProfileValueTalkPair;
+import org.yapp.domain.profile.presentation.response.ProfileBasicResponse;
 import org.yapp.domain.user.application.UserService;
 
 @Service
@@ -116,6 +119,22 @@ public class ProfileService {
         if (newImageUrl != null && !newImageUrl.equals(oldImageUrl)) {
             profileImageService.create(profile.getId(), newImageUrl);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public ProfileBasicResponse getProfileBasicNonPreview(Long userId) {
+        User user = userService.getUserById(userId);
+        Profile profile = user.getProfile();
+
+        ProfileImageDto profileImageDto = profileImageService.getProfileImageLatest(
+            profile.getId());
+        String latestProfileImageUrl = null;
+
+        if (profileImageDto != null && profileImageDto.status() == ProfileImageStatus.PENDING) {
+            latestProfileImageUrl = profileImageDto.imageUrl();
+        }
+
+        return ProfileBasicResponse.from(profile, latestProfileImageUrl);
     }
 
     @Transactional

--- a/api/src/main/java/org/yapp/domain/profile/application/ProfileService.java
+++ b/api/src/main/java/org/yapp/domain/profile/application/ProfileService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.yapp.core.domain.profile.Profile;
@@ -13,6 +14,7 @@ import org.yapp.core.domain.profile.ProfileImageStatus;
 import org.yapp.core.domain.profile.ProfileStatus;
 import org.yapp.core.domain.profile.ProfileValuePick;
 import org.yapp.core.domain.profile.ProfileValueTalk;
+import org.yapp.core.domain.profile.event.ProfileImageUpdatedEvent;
 import org.yapp.core.domain.user.RoleStatus;
 import org.yapp.core.domain.user.User;
 import org.yapp.core.exception.ApplicationException;
@@ -38,6 +40,7 @@ public class ProfileService {
     private final ProfileValueTalkService profileValueTalkService;
     private final ProfileImageService profileImageService;
     private final ProfileRepository profileRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public Profile create(ProfileCreateRequest dto) {
@@ -118,6 +121,8 @@ public class ProfileService {
 
         if (newImageUrl != null && !newImageUrl.equals(oldImageUrl)) {
             profileImageService.create(profile.getId(), newImageUrl);
+            eventPublisher.publishEvent(new ProfileImageUpdatedEvent(profile.getId(),
+                profile.getProfileBasic().getNickname()));
         }
     }
 

--- a/api/src/main/java/org/yapp/domain/profile/application/ProfileService.java
+++ b/api/src/main/java/org/yapp/domain/profile/application/ProfileService.java
@@ -35,6 +35,7 @@ public class ProfileService {
     private final UserService userService;
     private final ProfileValuePickService profileValuePickService;
     private final ProfileValueTalkService profileValueTalkService;
+    private final ProfileImageService profileImageService;
     private final ProfileRepository profileRepository;
 
     @Transactional
@@ -95,13 +96,27 @@ public class ProfileService {
     public Profile updateProfileBasic(long userId, ProfileBasicUpdateRequest dto) {
         User user = this.userService.getUserById(userId);
         Profile profile = getProfileById(user.getProfile().getId());
+        ProfileBasic newProfileBasic = dto.toProfileBasic();
 
-        ProfileBasic profileBasic = dto.toProfileBasic();
+        profileImageUpdate(profile, newProfileBasic.getImageUrl());
+        String oldImageUrl = null;
+        if (profile != null && profile.getProfileBasic() != null) {
+            oldImageUrl = profile.getProfileBasic().getImageUrl();
+        }
 
-        profile.updateBasic(profileBasic);
-        updateProfileRevised(profile);
-
+        newProfileBasic.setImageUrl(oldImageUrl);
         return profile;
+    }
+
+    private void profileImageUpdate(Profile profile, String newImageUrl) {
+        String oldImageUrl = null;
+        if (profile.getProfileBasic() != null) {
+            oldImageUrl = profile.getProfileBasic().getImageUrl();
+        }
+
+        if (newImageUrl != null && !newImageUrl.equals(oldImageUrl)) {
+            profileImageService.create(profile.getId(), newImageUrl);
+        }
     }
 
     @Transactional

--- a/api/src/main/java/org/yapp/domain/profile/application/ProfileService.java
+++ b/api/src/main/java/org/yapp/domain/profile/application/ProfileService.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.yapp.core.domain.profile.Profile;
@@ -26,6 +26,8 @@ import org.yapp.domain.profile.presentation.request.ProfileValueTalkUpdateReques
 import org.yapp.domain.profile.presentation.request.ProfileValueTalkUpdateRequest.ProfileValueTalkPair;
 import org.yapp.domain.user.application.UserService;
 
+import lombok.RequiredArgsConstructor;
+
 @Service
 @RequiredArgsConstructor
 public class ProfileService {
@@ -40,16 +42,15 @@ public class ProfileService {
         ProfileBasic profileBasic = dto.toProfileBasic();
 
         Profile profile = Profile.builder().profileBasic(profileBasic)
-            .build();
+                .build();
 
         profileRepository.save(profile);
 
         List<ProfileValuePick> allProfileValues = profileValuePickService.createAllProfileValuePicks(
-            profile.getId(), dto.valuePicks());
+                profile.getId(), dto.valuePicks());
 
         List<ProfileValueTalk> allProfileTalks = profileValueTalkService.createAllProfileValues(
-            profile.getId(), dto.valueTalks()
-        );
+                profile.getId(), dto.valueTalks());
 
         profile.updateProfileValuePicks(allProfileValues);
         profile.updateProfileValueTalks(allProfileTalks);
@@ -64,16 +65,15 @@ public class ProfileService {
         ProfileBasic profileBasic = dto.toProfileBasic();
 
         List<ProfileValuePick> allProfileValues = profileValuePickService.createAllProfileValuePicks(
-            profile.getId(), dto.valuePicks());
+                profile.getId(), dto.valuePicks());
 
         List<ProfileValueTalk> allProfileTalks = profileValueTalkService.createAllProfileValues(
-            profile.getId(), dto.valueTalks()
-        );
+                profile.getId(), dto.valueTalks());
 
         profile.updateBasic(profileBasic);
         profile.updateProfileValuePicks(allProfileValues);
         profile.updateProfileValueTalks(allProfileTalks);
-        updateProfileStatus(profile);
+        updateProfileRevised(profile);
 
         return profile;
     }
@@ -81,14 +81,14 @@ public class ProfileService {
     @Transactional(readOnly = true)
     public Profile getProfileById(long profileId) {
         return profileRepository.findById(profileId)
-            .orElseThrow(() -> new ApplicationException(ProfileErrorCode.NOTFOUND_PROFILE));
+                .orElseThrow(() -> new ApplicationException(ProfileErrorCode.NOTFOUND_PROFILE));
     }
 
     @Transactional(readOnly = true)
     public List<Profile> getValidProfilesByLocation(String locationName) {
         return profileRepository.findByProfileBasic_LocationAndUser_RoleAndUser_IsAdminIsNull(
-            locationName,
-            RoleStatus.USER.getStatus());
+                locationName,
+                RoleStatus.USER.getStatus());
     }
 
     @Transactional
@@ -99,7 +99,7 @@ public class ProfileService {
         ProfileBasic profileBasic = dto.toProfileBasic();
 
         profile.updateBasic(profileBasic);
-        updateProfileStatus(profile);
+        updateProfileRevised(profile);
 
         return profile;
     }
@@ -128,7 +128,6 @@ public class ProfileService {
             }
         }
 
-        updateProfileStatus(profile);
         return profile;
     }
 
@@ -140,12 +139,11 @@ public class ProfileService {
         List<ProfileValueTalk> profileValueTalks = profile.getProfileValueTalks();
 
         HashMap<Long, ProfileValueTalk> profileValueTalkHashMap = profileValueTalks.stream()
-            .collect(Collectors.toMap(
-                ProfileValueTalk::getId,
-                profileValueTalk -> profileValueTalk,
-                (existing, replacement) -> existing,
-                HashMap::new
-            ));
+                .collect(Collectors.toMap(
+                        ProfileValueTalk::getId,
+                        profileValueTalk -> profileValueTalk,
+                        (existing, replacement) -> existing,
+                        HashMap::new));
 
         for (ProfileValueTalkPair profileValuePickPair : dto.profileValueTalkUpdateRequests()) {
             final Long profileValueTalkId = profileValuePickPair.profileValueTalkId();
@@ -157,15 +155,14 @@ public class ProfileService {
             }
         }
 
-        updateProfileStatus(profile);
         return profile;
     }
 
-    private void updateProfileStatus(Profile profile) {
+    private void updateProfileRevised(Profile profile) {
         ProfileStatus profileStatus = profile.getProfileStatus();
 
         if (ProfileStatus.INCOMPLETE.equals(profileStatus) ||
-            ProfileStatus.REJECTED.equals(profileStatus)) {
+                ProfileStatus.REJECTED.equals(profileStatus)) {
             profile.updateProfileStatus(ProfileStatus.REVISED);
         }
     }

--- a/api/src/main/java/org/yapp/domain/profile/application/dto/ProfileImageDto.java
+++ b/api/src/main/java/org/yapp/domain/profile/application/dto/ProfileImageDto.java
@@ -1,0 +1,17 @@
+package org.yapp.domain.profile.application.dto;
+
+import org.yapp.core.domain.profile.ProfileImage;
+import org.yapp.core.domain.profile.ProfileImageStatus;
+
+public record ProfileImageDto(
+        Long profileId,
+        Long profileImageId,
+        String imageUrl,
+        ProfileImageStatus status) {
+
+    public static ProfileImageDto from(ProfileImage profileImage) {
+        return new ProfileImageDto(profileImage.getProfile().getId(), profileImage.getId(),
+                profileImage.getImageUrl(), profileImage.getStatus());
+    }
+
+}

--- a/api/src/main/java/org/yapp/domain/profile/dao/ProfileImageRepository.java
+++ b/api/src/main/java/org/yapp/domain/profile/dao/ProfileImageRepository.java
@@ -1,0 +1,17 @@
+package org.yapp.domain.profile.dao;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.yapp.core.domain.profile.ProfileImage;
+import org.yapp.core.domain.profile.ProfileImageStatus;
+
+public interface ProfileImageRepository extends JpaRepository<ProfileImage, Long> {
+
+    List<ProfileImage> findByProfileId(Long profileId);
+
+    List<ProfileImage> findByProfileIdAndStatus(Long profileId, ProfileImageStatus status);
+
+    Optional<ProfileImage> findTopByProfileIdOrderByCreatedAtDesc(Long profileId);
+}

--- a/api/src/main/java/org/yapp/domain/profile/presentation/ProfileController.java
+++ b/api/src/main/java/org/yapp/domain/profile/presentation/ProfileController.java
@@ -1,7 +1,12 @@
 package org.yapp.domain.profile.presentation;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
 import java.io.IOException;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -40,13 +45,6 @@ import org.yapp.format.CommonResponse;
 import org.yapp.infra.discord.DiscordMessageFactory;
 import org.yapp.infra.discord.DiscordNotificationService;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -62,156 +60,157 @@ public class ProfileController {
     private final DiscordNotificationService discordNotificationService;
 
     @PostMapping("")
-    @Operation(summary = "프로필 생성", description = "현재 로그인된 사용자의 프로필을 생성합니다.", tags = { "프로필" })
+    @Operation(summary = "프로필 생성", description = "현재 로그인된 사용자의 프로필을 생성합니다.", tags = {"프로필"})
     public ResponseEntity<CommonResponse<OauthLoginResponse>> createProfile(
-            @RequestBody @Valid ProfileCreateRequest request,
-            @AuthenticationPrincipal Long userId) {
+        @RequestBody @Valid ProfileCreateRequest request,
+        @AuthenticationPrincipal Long userId) {
 
         Profile profile = profileService.create(request);
         profileValueTalkSummaryService.summaryProfileValueTalksSync(profile);
         OauthLoginResponse oauthLoginResponse = userService.completeProfileInitialize(userId,
-                profile);
+            profile);
 
         discordNotificationService.sendNotification(
-                DiscordMessageFactory.createNewProfileMessage(profile.getId(),
-                        profile.getProfileBasic().getNickname()));
+            DiscordMessageFactory.createNewProfileMessage(profile.getId(),
+                profile.getProfileBasic().getNickname()));
 
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(CommonResponse.createSuccess(oauthLoginResponse));
+            .body(CommonResponse.createSuccess(oauthLoginResponse));
     }
 
     @PutMapping("")
-    @Operation(summary = "반려 프로필 수정", description = "반려 당한 사용자의 프로필을 수정합니다.", tags = { "프로필" })
+    @Operation(summary = "반려 프로필 수정", description = "반려 당한 사용자의 프로필을 수정합니다.", tags = {"프로필"})
     public ResponseEntity<CommonResponse<Void>> updateProfile(
-            @RequestBody @Valid ProfileUpdateRequest request,
-            @AuthenticationPrincipal Long userId) {
+        @RequestBody @Valid ProfileUpdateRequest request,
+        @AuthenticationPrincipal Long userId) {
 
         Profile profile = profileService.update(userId, request);
         profileValueTalkSummaryService.summaryProfileValueTalksSync(profile);
 
         discordNotificationService.sendNotification(
-                DiscordMessageFactory.createRenewProfileMessage(profile.getId(),
-                        profile.getProfileBasic().getNickname()));
+            DiscordMessageFactory.createRenewProfileMessage(profile.getId(),
+                profile.getProfileBasic().getNickname()));
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(CommonResponse.createSuccessWithNoContent("프로필 업데이트가 완료되었습니다."));
+            .body(CommonResponse.createSuccessWithNoContent("프로필 업데이트가 완료되었습니다."));
     }
 
     @GetMapping("/basic")
     @Operation(summary = "프로필 기본 정보 조회", description = "현재 로그인된 사용자의 프로필 기본 정보를 조회합니다.", tags = {
-            "프로필" })
+        "프로필"})
     @ApiResponse(responseCode = "200", description = "프로필이 성공적으로 조회되었습니다.")
     public ResponseEntity<CommonResponse<ProfileBasicResponse>> getProfileBasic(
-            @AuthenticationPrincipal Long userId) {
+        @AuthenticationPrincipal Long userId) {
 
         User user = userService.getUserById(userId);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(CommonResponse.createSuccess(ProfileBasicResponse.from(user.getProfile())));
+            .body(CommonResponse.createSuccess(ProfileBasicResponse.from(user.getProfile())));
     }
 
     @GetMapping("/basic/preview")
     @Operation(summary = "프로필 기본 정보 미리보기", description = "현재 로그인된 사용자의 프로필 기본 정보를 미리보기 합니다", tags = {
-            "프로필" })
+        "프로필"})
     @ApiResponse(responseCode = "200", description = "프로필 미리보기가 성공했습니다.")
     public ResponseEntity<CommonResponse<ProfileBasicPreviewResponse>> getProfileBasicPreview(
-            @AuthenticationPrincipal Long userId) {
+        @AuthenticationPrincipal Long userId) {
+
         User user = userService.getUserById(userId);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(CommonResponse.createSuccess(
-                        ProfileBasicPreviewResponse.fromProfile(user.getProfile())));
+            .body(CommonResponse.createSuccess(
+                ProfileBasicPreviewResponse.fromProfile(user.getProfile())));
     }
 
     @PutMapping("/basic")
     @Operation(summary = "프로필 기본 정보 업데이트", description = "현재 로그인된 사용자의 프로필 기본정보를 업데이트합니다.", tags = {
-            "프로필" })
+        "프로필"})
     @ApiResponse(responseCode = "200", description = "프로필 기본정보가 성공적으로 업데이트되었습니다.")
     public ResponseEntity<CommonResponse<ProfileBasicResponse>> updateProfile(
-            @AuthenticationPrincipal Long userId,
-            @RequestBody @Valid ProfileBasicUpdateRequest request) {
+        @AuthenticationPrincipal Long userId,
+        @RequestBody @Valid ProfileBasicUpdateRequest request) {
         Profile profile = profileService.updateProfileBasic(userId, request);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(CommonResponse.createSuccess(ProfileBasicResponse.from(profile)));
+            .body(CommonResponse.createSuccess(ProfileBasicResponse.from(profile, null)));
     }
 
     @GetMapping("/valuePicks")
     @Operation(summary = "프로필 가치관 Pick 정보 조회", description = "현재 로그인된 사용자가 입력한 프로필 가치관 Pick을 조회합니다.", tags = {
-            "프로필" })
+        "프로필"})
     @ApiResponse(responseCode = "200", description = "프로필이 성공적으로 조회되었습니다.")
     public ResponseEntity<CommonResponse<ProfileValuePickResponses>> getProfilePick(
-            @AuthenticationPrincipal Long userId) {
+        @AuthenticationPrincipal Long userId) {
         ProfileValuePickResponses profileValuePickResponses = profileValuePickService.getProfileValuePickResponses(
-                userId);
+            userId);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(CommonResponse.createSuccess(profileValuePickResponses));
+            .body(CommonResponse.createSuccess(profileValuePickResponses));
     }
 
     @PutMapping("/valuePicks")
     @Operation(summary = "프로필 가치관 Pick 업데이트", description = "현재 로그인된 사용자가 입력한 프로필 가치관 Pick을 업데이트합니다.", tags = {
-            "프로필" })
+        "프로필"})
     @ApiResponse(responseCode = "200", description = "프로필 가치관 Pick을 성공적으로 업데이트하였습니다.")
     public ResponseEntity<CommonResponse<ProfileValuePickResponses>> updateProfilePick(
-            @AuthenticationPrincipal Long userId,
-            @RequestBody ProfileValuePickUpdateRequest request) {
+        @AuthenticationPrincipal Long userId,
+        @RequestBody ProfileValuePickUpdateRequest request) {
 
         profileService.updateProfileValuePicks(userId, request);
         ProfileValuePickResponses profileValuePickResponses = profileValuePickService.getProfileValuePickResponses(
-                userId);
+            userId);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(CommonResponse.createSuccess(profileValuePickResponses));
+            .body(CommonResponse.createSuccess(profileValuePickResponses));
     }
 
     @GetMapping("/valueTalks")
     @Operation(summary = "프로필 가치관 Talk 정보 조회", description = "현재 로그인된 사용자가 입력한 프로필 가치관 Talk을 조회합니다.", tags = {
-            "프로필" })
+        "프로필"})
     @ApiResponse(responseCode = "200", description = "프로필이 성공적으로 조회되었습니다.")
     public ResponseEntity<CommonResponse<ProfileValueTalkResponses>> getProfileTalks(
-            @AuthenticationPrincipal Long userId) {
+        @AuthenticationPrincipal Long userId) {
 
         ProfileValueTalkResponses profileValueTalkResponses = profileValueTalkService.getProfileValueTalkResponses(
-                userId);
+            userId);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(CommonResponse.createSuccess(profileValueTalkResponses));
+            .body(CommonResponse.createSuccess(profileValueTalkResponses));
     }
 
     @PutMapping("/valueTalks")
     @Operation(summary = "프로필 가치관 Talk 업데이트", description = "현재 로그인된 사용자가 입력한 프로필 가치관 Talk 업데이트합니다.", tags = {
-            "프로필" })
+        "프로필"})
     @ApiResponse(responseCode = "200", description = "프로필 가치관 Talk 성공적으로 업데이트하였습니다.")
     public ResponseEntity<CommonResponse<ProfileValueTalkResponses>> updateProfileTalks(
-            @AuthenticationPrincipal Long userId,
-            @RequestBody ProfileValueTalkUpdateRequest request) {
+        @AuthenticationPrincipal Long userId,
+        @RequestBody ProfileValueTalkUpdateRequest request) {
 
         profileValueTalkSummaryService.summaryProfileValueTalksAsync(userId,
-                ProfileValueTalkAnswerDto.from(request));
+            ProfileValueTalkAnswerDto.from(request));
         profileService.updateProfileValueTalks(userId, request);
 
         ProfileValueTalkResponses profileValueTalkResponses = profileValueTalkService.getProfileValueTalkResponses(
-                userId);
+            userId);
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(CommonResponse.createSuccess(profileValueTalkResponses));
+            .body(CommonResponse.createSuccess(profileValueTalkResponses));
     }
 
     @PatchMapping("/valueTalks/{profileTalkId}/summary")
     @Operation(summary = "프로필 가치관 Talk 요약 업데이트", description = "프로필 가치관 Talk 요약을 사용자 입력값으로 업데이트합니다.", tags = {
-            "프로필"
+        "프로필"
     })
     public ResponseEntity<CommonResponse<Void>> updateProfileTalkSummary(
-            @PathVariable Long profileTalkId,
-            @Valid @RequestBody ProfileTalkSummaryUpdateRequest request) {
+        @PathVariable Long profileTalkId,
+        @Valid @RequestBody ProfileTalkSummaryUpdateRequest request) {
         profileValueTalkService.updateSummary(profileTalkId, request.summary());
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(CommonResponse.createSuccessWithNoContent("요약 업데이트가 성공하였습니다."));
+            .body(CommonResponse.createSuccessWithNoContent("요약 업데이트가 성공하였습니다."));
     }
 
     @PostMapping("/check-nickname")
     @Operation(summary = "프로필 닉네임 중복 확인", description = "요청 파라미터로 전달된 닉네임이 중복되는지 확인합니다.", tags = {
-            "프로필" })
+        "프로필"})
     @ApiResponse(responseCode = "200", description = "중복되지 않은 닉네임입니다.")
     public ResponseEntity<CommonResponse<Boolean>> checkNickname(@RequestParam String nickname) {
         boolean isAvailable = profileService.isNicknameAvailable(nickname);
@@ -219,13 +218,13 @@ public class ProfileController {
     }
 
     @PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "프로필 이미지 등록", description = "업로드한 이미지를 버킷에 등록합니다.", tags = { "프로필 이미지" })
+    @Operation(summary = "프로필 이미지 등록", description = "업로드한 이미지를 버킷에 등록합니다.", tags = {"프로필 이미지"})
     @ApiResponse(responseCode = "200", description = "이미지가 버킷에 저장되었습니다.")
     public ResponseEntity<CommonResponse<String>> uploadProfileImage(
-            @Parameter(description = "업로드할 프로필 이미지 파일 form-data 바이너리 파일 (JPEG, PNG, WEBP 지원)", required = true) @RequestParam("file") MultipartFile file)
-            throws IOException {
+        @Parameter(description = "업로드할 프로필 이미지 파일 form-data 바이너리 파일 (JPEG, PNG, WEBP 지원)", required = true) @RequestParam("file") MultipartFile file)
+        throws IOException {
         String profileImageUrl = profileImageService.uploadProfileImage(file);
         return ResponseEntity.status(HttpStatus.OK)
-                .body(CommonResponse.createSuccess(profileImageUrl));
+            .body(CommonResponse.createSuccess(profileImageUrl));
     }
 }

--- a/api/src/main/java/org/yapp/domain/profile/presentation/ProfileController.java
+++ b/api/src/main/java/org/yapp/domain/profile/presentation/ProfileController.java
@@ -1,12 +1,7 @@
 package org.yapp.domain.profile.presentation;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import jakarta.validation.Valid;
 import java.io.IOException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -45,6 +40,13 @@ import org.yapp.format.CommonResponse;
 import org.yapp.infra.discord.DiscordMessageFactory;
 import org.yapp.infra.discord.DiscordNotificationService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -60,154 +62,156 @@ public class ProfileController {
     private final DiscordNotificationService discordNotificationService;
 
     @PostMapping("")
-    @Operation(summary = "프로필 생성", description = "현재 로그인된 사용자의 프로필을 생성합니다.", tags = {"프로필"})
+    @Operation(summary = "프로필 생성", description = "현재 로그인된 사용자의 프로필을 생성합니다.", tags = { "프로필" })
     public ResponseEntity<CommonResponse<OauthLoginResponse>> createProfile(
-        @RequestBody @Valid ProfileCreateRequest request,
-        @AuthenticationPrincipal Long userId) {
+            @RequestBody @Valid ProfileCreateRequest request,
+            @AuthenticationPrincipal Long userId) {
 
         Profile profile = profileService.create(request);
         profileValueTalkSummaryService.summaryProfileValueTalksSync(profile);
         OauthLoginResponse oauthLoginResponse = userService.completeProfileInitialize(userId,
-            profile);
+                profile);
 
         discordNotificationService.sendNotification(
-            DiscordMessageFactory.createNewProfileMessage(profile.getId(),
-                profile.getProfileBasic().getNickname()));
+                DiscordMessageFactory.createNewProfileMessage(profile.getId(),
+                        profile.getProfileBasic().getNickname()));
 
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(CommonResponse.createSuccess(oauthLoginResponse));
+                .body(CommonResponse.createSuccess(oauthLoginResponse));
     }
 
     @PutMapping("")
-    @Operation(summary = "반려 프로필 수정", description = "반려 당한 사용자의 프로필을 수정합니다.", tags = {"프로필"})
+    @Operation(summary = "반려 프로필 수정", description = "반려 당한 사용자의 프로필을 수정합니다.", tags = { "프로필" })
     public ResponseEntity<CommonResponse<Void>> updateProfile(
-        @RequestBody @Valid ProfileUpdateRequest request,
-        @AuthenticationPrincipal Long userId) {
+            @RequestBody @Valid ProfileUpdateRequest request,
+            @AuthenticationPrincipal Long userId) {
 
         Profile profile = profileService.update(userId, request);
         profileValueTalkSummaryService.summaryProfileValueTalksSync(profile);
 
         discordNotificationService.sendNotification(
-            DiscordMessageFactory.createRenewProfileMessage(profile.getId(),
-                profile.getProfileBasic().getNickname()));
+                DiscordMessageFactory.createRenewProfileMessage(profile.getId(),
+                        profile.getProfileBasic().getNickname()));
 
         return ResponseEntity.status(HttpStatus.OK)
-            .body(CommonResponse.createSuccessWithNoContent("프로필 업데이트가 완료되었습니다."));
+                .body(CommonResponse.createSuccessWithNoContent("프로필 업데이트가 완료되었습니다."));
     }
 
     @GetMapping("/basic")
     @Operation(summary = "프로필 기본 정보 조회", description = "현재 로그인된 사용자의 프로필 기본 정보를 조회합니다.", tags = {
-        "프로필"})
+            "프로필" })
     @ApiResponse(responseCode = "200", description = "프로필이 성공적으로 조회되었습니다.")
     public ResponseEntity<CommonResponse<ProfileBasicResponse>> getProfileBasic(
-        @AuthenticationPrincipal Long userId) {
+            @AuthenticationPrincipal Long userId) {
+
         User user = userService.getUserById(userId);
+
         return ResponseEntity.status(HttpStatus.OK)
-            .body(CommonResponse.createSuccess(ProfileBasicResponse.from(user.getProfile())));
+                .body(CommonResponse.createSuccess(ProfileBasicResponse.from(user.getProfile())));
     }
 
     @GetMapping("/basic/preview")
     @Operation(summary = "프로필 기본 정보 미리보기", description = "현재 로그인된 사용자의 프로필 기본 정보를 미리보기 합니다", tags = {
-        "프로필"})
+            "프로필" })
     @ApiResponse(responseCode = "200", description = "프로필 미리보기가 성공했습니다.")
     public ResponseEntity<CommonResponse<ProfileBasicPreviewResponse>> getProfileBasicPreview(
-        @AuthenticationPrincipal Long userId) {
+            @AuthenticationPrincipal Long userId) {
         User user = userService.getUserById(userId);
 
         return ResponseEntity.status(HttpStatus.OK)
-            .body(CommonResponse.createSuccess(
-                ProfileBasicPreviewResponse.fromProfile(user.getProfile())));
+                .body(CommonResponse.createSuccess(
+                        ProfileBasicPreviewResponse.fromProfile(user.getProfile())));
     }
 
     @PutMapping("/basic")
     @Operation(summary = "프로필 기본 정보 업데이트", description = "현재 로그인된 사용자의 프로필 기본정보를 업데이트합니다.", tags = {
-        "프로필"})
+            "프로필" })
     @ApiResponse(responseCode = "200", description = "프로필 기본정보가 성공적으로 업데이트되었습니다.")
     public ResponseEntity<CommonResponse<ProfileBasicResponse>> updateProfile(
-        @AuthenticationPrincipal Long userId,
-        @RequestBody @Valid ProfileBasicUpdateRequest request) {
+            @AuthenticationPrincipal Long userId,
+            @RequestBody @Valid ProfileBasicUpdateRequest request) {
         Profile profile = profileService.updateProfileBasic(userId, request);
         return ResponseEntity.status(HttpStatus.OK)
-            .body(CommonResponse.createSuccess(ProfileBasicResponse.from(profile)));
+                .body(CommonResponse.createSuccess(ProfileBasicResponse.from(profile)));
     }
 
     @GetMapping("/valuePicks")
     @Operation(summary = "프로필 가치관 Pick 정보 조회", description = "현재 로그인된 사용자가 입력한 프로필 가치관 Pick을 조회합니다.", tags = {
-        "프로필"})
+            "프로필" })
     @ApiResponse(responseCode = "200", description = "프로필이 성공적으로 조회되었습니다.")
     public ResponseEntity<CommonResponse<ProfileValuePickResponses>> getProfilePick(
-        @AuthenticationPrincipal Long userId) {
+            @AuthenticationPrincipal Long userId) {
         ProfileValuePickResponses profileValuePickResponses = profileValuePickService.getProfileValuePickResponses(
-            userId);
+                userId);
         return ResponseEntity.status(HttpStatus.OK)
-            .body(CommonResponse.createSuccess(profileValuePickResponses));
+                .body(CommonResponse.createSuccess(profileValuePickResponses));
     }
 
     @PutMapping("/valuePicks")
     @Operation(summary = "프로필 가치관 Pick 업데이트", description = "현재 로그인된 사용자가 입력한 프로필 가치관 Pick을 업데이트합니다.", tags = {
-        "프로필"})
+            "프로필" })
     @ApiResponse(responseCode = "200", description = "프로필 가치관 Pick을 성공적으로 업데이트하였습니다.")
     public ResponseEntity<CommonResponse<ProfileValuePickResponses>> updateProfilePick(
-        @AuthenticationPrincipal Long userId,
-        @RequestBody ProfileValuePickUpdateRequest request) {
+            @AuthenticationPrincipal Long userId,
+            @RequestBody ProfileValuePickUpdateRequest request) {
 
         profileService.updateProfileValuePicks(userId, request);
         ProfileValuePickResponses profileValuePickResponses = profileValuePickService.getProfileValuePickResponses(
-            userId);
+                userId);
 
         return ResponseEntity.status(HttpStatus.OK)
-            .body(CommonResponse.createSuccess(profileValuePickResponses));
+                .body(CommonResponse.createSuccess(profileValuePickResponses));
     }
 
     @GetMapping("/valueTalks")
     @Operation(summary = "프로필 가치관 Talk 정보 조회", description = "현재 로그인된 사용자가 입력한 프로필 가치관 Talk을 조회합니다.", tags = {
-        "프로필"})
+            "프로필" })
     @ApiResponse(responseCode = "200", description = "프로필이 성공적으로 조회되었습니다.")
     public ResponseEntity<CommonResponse<ProfileValueTalkResponses>> getProfileTalks(
-        @AuthenticationPrincipal Long userId) {
+            @AuthenticationPrincipal Long userId) {
 
         ProfileValueTalkResponses profileValueTalkResponses = profileValueTalkService.getProfileValueTalkResponses(
-            userId);
+                userId);
 
         return ResponseEntity.status(HttpStatus.OK)
-            .body(CommonResponse.createSuccess(profileValueTalkResponses));
+                .body(CommonResponse.createSuccess(profileValueTalkResponses));
     }
 
     @PutMapping("/valueTalks")
     @Operation(summary = "프로필 가치관 Talk 업데이트", description = "현재 로그인된 사용자가 입력한 프로필 가치관 Talk 업데이트합니다.", tags = {
-        "프로필"})
+            "프로필" })
     @ApiResponse(responseCode = "200", description = "프로필 가치관 Talk 성공적으로 업데이트하였습니다.")
     public ResponseEntity<CommonResponse<ProfileValueTalkResponses>> updateProfileTalks(
-        @AuthenticationPrincipal Long userId,
-        @RequestBody ProfileValueTalkUpdateRequest request) {
+            @AuthenticationPrincipal Long userId,
+            @RequestBody ProfileValueTalkUpdateRequest request) {
 
         profileValueTalkSummaryService.summaryProfileValueTalksAsync(userId,
-            ProfileValueTalkAnswerDto.from(request));
+                ProfileValueTalkAnswerDto.from(request));
         profileService.updateProfileValueTalks(userId, request);
 
         ProfileValueTalkResponses profileValueTalkResponses = profileValueTalkService.getProfileValueTalkResponses(
-            userId);
+                userId);
 
         return ResponseEntity.status(HttpStatus.OK)
-            .body(CommonResponse.createSuccess(profileValueTalkResponses));
+                .body(CommonResponse.createSuccess(profileValueTalkResponses));
     }
 
     @PatchMapping("/valueTalks/{profileTalkId}/summary")
     @Operation(summary = "프로필 가치관 Talk 요약 업데이트", description = "프로필 가치관 Talk 요약을 사용자 입력값으로 업데이트합니다.", tags = {
-        "프로필"
+            "프로필"
     })
     public ResponseEntity<CommonResponse<Void>> updateProfileTalkSummary(
-        @PathVariable Long profileTalkId,
-        @Valid @RequestBody ProfileTalkSummaryUpdateRequest request) {
+            @PathVariable Long profileTalkId,
+            @Valid @RequestBody ProfileTalkSummaryUpdateRequest request) {
         profileValueTalkService.updateSummary(profileTalkId, request.summary());
 
         return ResponseEntity.status(HttpStatus.OK)
-            .body(CommonResponse.createSuccessWithNoContent("요약 업데이트가 성공하였습니다."));
+                .body(CommonResponse.createSuccessWithNoContent("요약 업데이트가 성공하였습니다."));
     }
 
     @PostMapping("/check-nickname")
     @Operation(summary = "프로필 닉네임 중복 확인", description = "요청 파라미터로 전달된 닉네임이 중복되는지 확인합니다.", tags = {
-        "프로필"})
+            "프로필" })
     @ApiResponse(responseCode = "200", description = "중복되지 않은 닉네임입니다.")
     public ResponseEntity<CommonResponse<Boolean>> checkNickname(@RequestParam String nickname) {
         boolean isAvailable = profileService.isNicknameAvailable(nickname);
@@ -215,13 +219,13 @@ public class ProfileController {
     }
 
     @PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "프로필 이미지 등록", description = "업로드한 이미지를 버킷에 등록합니다.", tags = {"프로필 이미지"})
+    @Operation(summary = "프로필 이미지 등록", description = "업로드한 이미지를 버킷에 등록합니다.", tags = { "프로필 이미지" })
     @ApiResponse(responseCode = "200", description = "이미지가 버킷에 저장되었습니다.")
     public ResponseEntity<CommonResponse<String>> uploadProfileImage(
-        @Parameter(description = "업로드할 프로필 이미지 파일 form-data 바이너리 파일 (JPEG, PNG, WEBP 지원)", required = true)
-        @RequestParam("file") MultipartFile file) throws IOException {
+            @Parameter(description = "업로드할 프로필 이미지 파일 form-data 바이너리 파일 (JPEG, PNG, WEBP 지원)", required = true) @RequestParam("file") MultipartFile file)
+            throws IOException {
         String profileImageUrl = profileImageService.uploadProfileImage(file);
         return ResponseEntity.status(HttpStatus.OK)
-            .body(CommonResponse.createSuccess(profileImageUrl));
+                .body(CommonResponse.createSuccess(profileImageUrl));
     }
 }

--- a/api/src/main/java/org/yapp/domain/profile/presentation/ProfileController.java
+++ b/api/src/main/java/org/yapp/domain/profile/presentation/ProfileController.java
@@ -1,7 +1,12 @@
 package org.yapp.domain.profile.presentation;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
 import java.io.IOException;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -42,62 +47,55 @@ import org.yapp.domain.profile.presentation.response.ProfileValueTalkResponses;
 import org.yapp.domain.user.application.UserService;
 import org.yapp.format.CommonResponse;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/profiles")
 public class ProfileController {
 
-        private final ProfileService profileService;
-        private final UserService userService;
-        private final ProfileImageService profileImageService;
-        private final ProfileValuePickService profileValuePickService;
-        private final ProfileValueTalkService profileValueTalkService;
-        private final ProfileValueTalkSummaryService profileValueTalkSummaryService;
-        private final ApplicationEventPublisher eventPublisher;
+    private final ProfileService profileService;
+    private final UserService userService;
+    private final ProfileImageService profileImageService;
+    private final ProfileValuePickService profileValuePickService;
+    private final ProfileValueTalkService profileValueTalkService;
+    private final ProfileValueTalkSummaryService profileValueTalkSummaryService;
+    private final ApplicationEventPublisher eventPublisher;
 
-        @PostMapping("")
-        @Operation(summary = "프로필 생성", description = "현재 로그인된 사용자의 프로필을 생성합니다.", tags = { "프로필" })
-        public ResponseEntity<CommonResponse<OauthLoginResponse>> createProfile(
-                        @RequestBody @Valid ProfileCreateRequest request,
-                        @AuthenticationPrincipal Long userId) {
+    @PostMapping("")
+    @Operation(summary = "프로필 생성", description = "현재 로그인된 사용자의 프로필을 생성합니다.", tags = {"프로필"})
+    public ResponseEntity<CommonResponse<OauthLoginResponse>> createProfile(
+        @RequestBody @Valid ProfileCreateRequest request,
+        @AuthenticationPrincipal Long userId) {
 
-                Profile profile = profileService.create(request);
-                profileValueTalkSummaryService.summaryProfileValueTalksSync(profile);
-                OauthLoginResponse oauthLoginResponse = userService.completeProfileInitialize(userId,
-                                profile);
+        Profile profile = profileService.create(request);
+        profileValueTalkSummaryService.summaryProfileValueTalksSync(profile);
+        OauthLoginResponse oauthLoginResponse = userService.completeProfileInitialize(userId,
+            profile);
 
-                eventPublisher.publishEvent(new ProfileCreatedEvent(
-                                profile.getId(),
-                                profile.getProfileBasic().getNickname()));
+        eventPublisher.publishEvent(new ProfileCreatedEvent(
+            profile.getId(),
+            profile.getProfileBasic().getNickname()));
 
-                return ResponseEntity.status(HttpStatus.CREATED)
-                                .body(CommonResponse.createSuccess(oauthLoginResponse));
-        }
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(CommonResponse.createSuccess(oauthLoginResponse));
+    }
 
-        @PutMapping("")
-        @Operation(summary = "반려 프로필 수정", description = "반려 당한 사용자의 프로필을 수정합니다.", tags = { "프로필" })
-        public ResponseEntity<CommonResponse<Void>> updateProfile(
-                        @RequestBody @Valid ProfileUpdateRequest request,
-                        @AuthenticationPrincipal Long userId) {
+    @PutMapping("")
+    @Operation(summary = "반려 프로필 수정", description = "반려 당한 사용자의 프로필을 수정합니다.", tags = {"프로필"})
+    public ResponseEntity<CommonResponse<Void>> updateProfile(
+        @RequestBody @Valid ProfileUpdateRequest request,
+        @AuthenticationPrincipal Long userId) {
 
-                Profile profile = profileService.update(userId, request);
-                profileValueTalkSummaryService.summaryProfileValueTalksSync(profile);
+        Profile profile = profileService.update(userId, request);
+        profileValueTalkSummaryService.summaryProfileValueTalksSync(profile);
 
-                eventPublisher.publishEvent(new ProfileRenewedEvent(
-                                profile.getId(),
-                                profile.getProfileBasic().getNickname()));
+        eventPublisher.publishEvent(new ProfileRenewedEvent(
+            profile.getId(),
+            profile.getProfileBasic().getNickname()));
 
-                return ResponseEntity.status(HttpStatus.OK)
-                                .body(CommonResponse.createSuccessWithNoContent("프로필 업데이트가 완료되었습니다."));
-        }
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(CommonResponse.createSuccessWithNoContent("프로필 업데이트가 완료되었습니다."));
+    }
 
     @GetMapping("/basic")
     @Operation(summary = "프로필 기본 정보 조회", description = "현재 로그인된 사용자의 프로필 기본 정보를 조회합니다.", tags = {
@@ -139,104 +137,104 @@ public class ProfileController {
             .body(CommonResponse.createSuccess(ProfileBasicResponse.from(profile, null)));
     }
 
-        @GetMapping("/valuePicks")
-        @Operation(summary = "프로필 가치관 Pick 정보 조회", description = "현재 로그인된 사용자가 입력한 프로필 가치관 Pick을 조회합니다.", tags = {
-                        "프로필" })
-        @ApiResponse(responseCode = "200", description = "프로필이 성공적으로 조회되었습니다.")
-        public ResponseEntity<CommonResponse<ProfileValuePickResponses>> getProfilePick(
-                        @AuthenticationPrincipal Long userId) {
-                ProfileValuePickResponses profileValuePickResponses = profileValuePickService
-                                .getProfileValuePickResponses(
-                                                userId);
-                return ResponseEntity.status(HttpStatus.OK)
-                                .body(CommonResponse.createSuccess(profileValuePickResponses));
-        }
+    @GetMapping("/valuePicks")
+    @Operation(summary = "프로필 가치관 Pick 정보 조회", description = "현재 로그인된 사용자가 입력한 프로필 가치관 Pick을 조회합니다.", tags = {
+        "프로필"})
+    @ApiResponse(responseCode = "200", description = "프로필이 성공적으로 조회되었습니다.")
+    public ResponseEntity<CommonResponse<ProfileValuePickResponses>> getProfilePick(
+        @AuthenticationPrincipal Long userId) {
+        ProfileValuePickResponses profileValuePickResponses = profileValuePickService
+            .getProfileValuePickResponses(
+                userId);
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(CommonResponse.createSuccess(profileValuePickResponses));
+    }
 
-        @PutMapping("/valuePicks")
-        @Operation(summary = "프로필 가치관 Pick 업데이트", description = "현재 로그인된 사용자가 입력한 프로필 가치관 Pick을 업데이트합니다.", tags = {
-                        "프로필" })
-        @ApiResponse(responseCode = "200", description = "프로필 가치관 Pick을 성공적으로 업데이트하였습니다.")
-        public ResponseEntity<CommonResponse<ProfileValuePickResponses>> updateProfilePick(
-                        @AuthenticationPrincipal Long userId,
-                        @RequestBody ProfileValuePickUpdateRequest request) {
+    @PutMapping("/valuePicks")
+    @Operation(summary = "프로필 가치관 Pick 업데이트", description = "현재 로그인된 사용자가 입력한 프로필 가치관 Pick을 업데이트합니다.", tags = {
+        "프로필"})
+    @ApiResponse(responseCode = "200", description = "프로필 가치관 Pick을 성공적으로 업데이트하였습니다.")
+    public ResponseEntity<CommonResponse<ProfileValuePickResponses>> updateProfilePick(
+        @AuthenticationPrincipal Long userId,
+        @RequestBody ProfileValuePickUpdateRequest request) {
 
-                profileService.updateProfileValuePicks(userId, request);
-                ProfileValuePickResponses profileValuePickResponses = profileValuePickService
-                                .getProfileValuePickResponses(
-                                                userId);
+        profileService.updateProfileValuePicks(userId, request);
+        ProfileValuePickResponses profileValuePickResponses = profileValuePickService
+            .getProfileValuePickResponses(
+                userId);
 
-                return ResponseEntity.status(HttpStatus.OK)
-                                .body(CommonResponse.createSuccess(profileValuePickResponses));
-        }
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(CommonResponse.createSuccess(profileValuePickResponses));
+    }
 
-        @GetMapping("/valueTalks")
-        @Operation(summary = "프로필 가치관 Talk 정보 조회", description = "현재 로그인된 사용자가 입력한 프로필 가치관 Talk을 조회합니다.", tags = {
-                        "프로필" })
-        @ApiResponse(responseCode = "200", description = "프로필이 성공적으로 조회되었습니다.")
-        public ResponseEntity<CommonResponse<ProfileValueTalkResponses>> getProfileTalks(
-                        @AuthenticationPrincipal Long userId) {
+    @GetMapping("/valueTalks")
+    @Operation(summary = "프로필 가치관 Talk 정보 조회", description = "현재 로그인된 사용자가 입력한 프로필 가치관 Talk을 조회합니다.", tags = {
+        "프로필"})
+    @ApiResponse(responseCode = "200", description = "프로필이 성공적으로 조회되었습니다.")
+    public ResponseEntity<CommonResponse<ProfileValueTalkResponses>> getProfileTalks(
+        @AuthenticationPrincipal Long userId) {
 
-                ProfileValueTalkResponses profileValueTalkResponses = profileValueTalkService
-                                .getProfileValueTalkResponses(
-                                                userId);
+        ProfileValueTalkResponses profileValueTalkResponses = profileValueTalkService
+            .getProfileValueTalkResponses(
+                userId);
 
-                return ResponseEntity.status(HttpStatus.OK)
-                                .body(CommonResponse.createSuccess(profileValueTalkResponses));
-        }
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(CommonResponse.createSuccess(profileValueTalkResponses));
+    }
 
-        @PutMapping("/valueTalks")
-        @Operation(summary = "프로필 가치관 Talk 업데이트", description = "현재 로그인된 사용자가 입력한 프로필 가치관 Talk 업데이트합니다.", tags = {
-                        "프로필" })
-        @ApiResponse(responseCode = "200", description = "프로필 가치관 Talk 성공적으로 업데이트하였습니다.")
-        public ResponseEntity<CommonResponse<ProfileValueTalkResponses>> updateProfileTalks(
-                        @AuthenticationPrincipal Long userId,
-                        @RequestBody ProfileValueTalkUpdateRequest request) {
+    @PutMapping("/valueTalks")
+    @Operation(summary = "프로필 가치관 Talk 업데이트", description = "현재 로그인된 사용자가 입력한 프로필 가치관 Talk 업데이트합니다.", tags = {
+        "프로필"})
+    @ApiResponse(responseCode = "200", description = "프로필 가치관 Talk 성공적으로 업데이트하였습니다.")
+    public ResponseEntity<CommonResponse<ProfileValueTalkResponses>> updateProfileTalks(
+        @AuthenticationPrincipal Long userId,
+        @RequestBody ProfileValueTalkUpdateRequest request) {
 
-                profileValueTalkSummaryService.summaryProfileValueTalksAsync(userId,
-                                ProfileValueTalkAnswerDto.from(request));
-                Profile profile = profileService.updateProfileValueTalks(userId, request);
-                eventPublisher.publishEvent(new ProfileValueTalkUpdatedEvent(
-                                profile.getId(),
-                                profile.getProfileBasic().getNickname()));
+        profileValueTalkSummaryService.summaryProfileValueTalksAsync(userId,
+            ProfileValueTalkAnswerDto.from(request));
+        Profile profile = profileService.updateProfileValueTalks(userId, request);
+        eventPublisher.publishEvent(new ProfileValueTalkUpdatedEvent(
+            profile.getId(),
+            profile.getProfileBasic().getNickname()));
 
-                ProfileValueTalkResponses profileValueTalkResponses = profileValueTalkService
-                                .getProfileValueTalkResponses(
-                                                userId);
+        ProfileValueTalkResponses profileValueTalkResponses = profileValueTalkService
+            .getProfileValueTalkResponses(
+                userId);
 
-                return ResponseEntity.status(HttpStatus.OK)
-                                .body(CommonResponse.createSuccess(profileValueTalkResponses));
-        }
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(CommonResponse.createSuccess(profileValueTalkResponses));
+    }
 
-        @PatchMapping("/valueTalks/{profileTalkId}/summary")
-        @Operation(summary = "프로필 가치관 Talk 요약 업데이트", description = "프로필 가치관 Talk 요약을 사용자 입력값으로 업데이트합니다.", tags = {
-                        "프로필"
-        })
-        public ResponseEntity<CommonResponse<Void>> updateProfileTalkSummary(
-                        @PathVariable Long profileTalkId,
-                        @Valid @RequestBody ProfileTalkSummaryUpdateRequest request) {
-                profileValueTalkService.updateSummary(profileTalkId, request.summary());
+    @PatchMapping("/valueTalks/{profileTalkId}/summary")
+    @Operation(summary = "프로필 가치관 Talk 요약 업데이트", description = "프로필 가치관 Talk 요약을 사용자 입력값으로 업데이트합니다.", tags = {
+        "프로필"
+    })
+    public ResponseEntity<CommonResponse<Void>> updateProfileTalkSummary(
+        @PathVariable Long profileTalkId,
+        @Valid @RequestBody ProfileTalkSummaryUpdateRequest request) {
+        profileValueTalkService.updateSummary(profileTalkId, request.summary());
 
-                return ResponseEntity.status(HttpStatus.OK)
-                                .body(CommonResponse.createSuccessWithNoContent("요약 업데이트가 성공하였습니다."));
-        }
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(CommonResponse.createSuccessWithNoContent("요약 업데이트가 성공하였습니다."));
+    }
 
-        @PostMapping("/check-nickname")
-        @Operation(summary = "프로필 닉네임 중복 확인", description = "요청 파라미터로 전달된 닉네임이 중복되는지 확인합니다.", tags = {
-                        "프로필" })
-        @ApiResponse(responseCode = "200", description = "중복되지 않은 닉네임입니다.")
-        public ResponseEntity<CommonResponse<Boolean>> checkNickname(@RequestParam String nickname) {
-                boolean isAvailable = profileService.isNicknameAvailable(nickname);
-                return ResponseEntity.status(HttpStatus.OK).body(CommonResponse.createSuccess(isAvailable));
-        }
+    @PostMapping("/check-nickname")
+    @Operation(summary = "프로필 닉네임 중복 확인", description = "요청 파라미터로 전달된 닉네임이 중복되는지 확인합니다.", tags = {
+        "프로필"})
+    @ApiResponse(responseCode = "200", description = "중복되지 않은 닉네임입니다.")
+    public ResponseEntity<CommonResponse<Boolean>> checkNickname(@RequestParam String nickname) {
+        boolean isAvailable = profileService.isNicknameAvailable(nickname);
+        return ResponseEntity.status(HttpStatus.OK).body(CommonResponse.createSuccess(isAvailable));
+    }
 
-        @PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-        @Operation(summary = "프로필 이미지 등록", description = "업로드한 이미지를 버킷에 등록합니다.", tags = { "프로필 이미지" })
-        @ApiResponse(responseCode = "200", description = "이미지가 버킷에 저장되었습니다.")
-        public ResponseEntity<CommonResponse<String>> uploadProfileImage(
-                        @Parameter(description = "업로드할 프로필 이미지 파일 form-data 바이너리 파일 (JPEG, PNG, WEBP 지원)", required = true) @RequestParam("file") MultipartFile file)
-                        throws IOException {
-                String profileImageUrl = profileImageService.uploadProfileImage(file);
-                return ResponseEntity.status(HttpStatus.OK)
-                                .body(CommonResponse.createSuccess(profileImageUrl));
-        }
+    @PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "프로필 이미지 등록", description = "업로드한 이미지를 버킷에 등록합니다.", tags = {"프로필 이미지"})
+    @ApiResponse(responseCode = "200", description = "이미지가 버킷에 저장되었습니다.")
+    public ResponseEntity<CommonResponse<String>> uploadProfileImage(
+        @Parameter(description = "업로드할 프로필 이미지 파일 form-data 바이너리 파일 (JPEG, PNG, WEBP 지원)", required = true) @RequestParam("file") MultipartFile file)
+        throws IOException {
+        String profileImageUrl = profileImageService.uploadProfileImage(file);
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(CommonResponse.createSuccess(profileImageUrl));
+    }
 }

--- a/api/src/main/java/org/yapp/domain/profile/presentation/ProfileController.java
+++ b/api/src/main/java/org/yapp/domain/profile/presentation/ProfileController.java
@@ -102,10 +102,11 @@ public class ProfileController {
     public ResponseEntity<CommonResponse<ProfileBasicResponse>> getProfileBasic(
         @AuthenticationPrincipal Long userId) {
 
-        User user = userService.getUserById(userId);
+        ProfileBasicResponse response = profileService.getProfileBasicNonPreview(
+            userId);
 
         return ResponseEntity.status(HttpStatus.OK)
-            .body(CommonResponse.createSuccess(ProfileBasicResponse.from(user.getProfile())));
+            .body(CommonResponse.createSuccess(response));
     }
 
     @GetMapping("/basic/preview")

--- a/api/src/main/java/org/yapp/domain/profile/presentation/response/ProfileBasicResponse.java
+++ b/api/src/main/java/org/yapp/domain/profile/presentation/response/ProfileBasicResponse.java
@@ -11,9 +11,10 @@ public record ProfileBasicResponse(String nickname, String description, int age,
                                    String location,
                                    String smokingStatus, Integer weight, String snsActivityLevel,
                                    String imageUrl,
+                                   String pendingImageUrl,
                                    List<ContactResponse> contacts) {
 
-    public static ProfileBasicResponse from(Profile profile) {
+    public static ProfileBasicResponse from(Profile profile, String pendingImageUrl) {
 
         ProfileBasic basic = profile.getProfileBasic();
 
@@ -24,6 +25,7 @@ public record ProfileBasicResponse(String nickname, String description, int age,
             basic.getJob(), basic.getLocation(), basic.getSmokingStatus(), basic.getWeight(),
             basic.getSnsActivityLevel(),
             basic.getImageUrl(),
+            pendingImageUrl,
             ContactResponses.convert(basic.getContacts()));
     }
 }

--- a/core/domain/src/main/java/org/yapp/core/domain/notification/enums/NotificationType.java
+++ b/core/domain/src/main/java/org/yapp/core/domain/notification/enums/NotificationType.java
@@ -1,9 +1,11 @@
 package org.yapp.core.domain.notification.enums;
 
 public enum NotificationType {
-  PROFILE_APPROVED,
-  PROFILE_REJECTED,
-  MATCH_NEW,
-  MATCH_ACCEPTED,
-  MATCH_COMPLETED
+    PROFILE_APPROVED,
+    PROFILE_REJECTED,
+    PROFILE_IMAGE_APPROVED,
+    PROFILE_IMAGE_REJECTED,
+    MATCH_NEW,
+    MATCH_ACCEPTED,
+    MATCH_COMPLETED
 }

--- a/core/domain/src/main/java/org/yapp/core/domain/profile/Profile.java
+++ b/core/domain/src/main/java/org/yapp/core/domain/profile/Profile.java
@@ -1,5 +1,10 @@
 package org.yapp.core.domain.profile;
 
+import java.util.List;
+
+import org.yapp.core.domain.BaseEntity;
+import org.yapp.core.domain.user.User;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -12,13 +17,10 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.yapp.core.domain.BaseEntity;
-import org.yapp.core.domain.user.User;
 
 @Table(name = "profile")
 @Entity
@@ -51,6 +53,29 @@ public class Profile extends BaseEntity {
 
     public void updateBasic(ProfileBasic profileBasic) {
         this.profileBasic = profileBasic;
+    }
+
+    public void updateProfileImageUrl(String imageUrl) {
+        ProfileBasic profileBasic = this.profileBasic;
+
+        if (profileBasic != null) {
+
+            ProfileBasic updatedBasic = ProfileBasic.builder()
+                    .nickname(profileBasic.getNickname())
+                    .description(profileBasic.getDescription())
+                    .birthdate(profileBasic.getBirthdate())
+                    .height(profileBasic.getHeight())
+                    .job(profileBasic.getJob())
+                    .location(profileBasic.getLocation())
+                    .smokingStatus(profileBasic.getSmokingStatus())
+                    .weight(profileBasic.getWeight())
+                    .snsActivityLevel(profileBasic.getSnsActivityLevel())
+                    .contacts(profileBasic.getContacts())
+                    .imageUrl(imageUrl)
+                    .build();
+
+            this.updateBasic(updatedBasic);
+        }
     }
 
     public void updateProfileValuePicks(List<ProfileValuePick> profileValuePicks) {

--- a/core/domain/src/main/java/org/yapp/core/domain/profile/ProfileBasic.java
+++ b/core/domain/src/main/java/org/yapp/core/domain/profile/ProfileBasic.java
@@ -1,16 +1,18 @@
 package org.yapp.core.domain.profile;
 
+import java.time.LocalDate;
+import java.util.Map;
+
+import org.hibernate.annotations.Type;
+
 import io.hypersistence.utils.hibernate.type.json.JsonType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import java.time.LocalDate;
-import java.util.Map;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Type;
 
 @Embeddable
 @Getter
@@ -51,5 +53,9 @@ public class ProfileBasic {
     private Map<ContactType, String> contacts;
 
     @Column(name = "image_url")
-    private String imageUrl;
+    private String imageUrl; // 프로필에서 보여줄 이미지. (상대방에게 및 프로필 미리보기에서 보여줄 이미지)
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 }

--- a/core/domain/src/main/java/org/yapp/core/domain/profile/ProfileImage.java
+++ b/core/domain/src/main/java/org/yapp/core/domain/profile/ProfileImage.java
@@ -1,9 +1,9 @@
 package org.yapp.core.domain.profile;
 
-import org.yapp.core.domain.BaseEntity;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.yapp.core.domain.BaseEntity;
 
 @Entity
 @Getter
@@ -34,6 +35,7 @@ public class ProfileImage extends BaseEntity {
     private String imageUrl;
 
     @Column(name = "status")
+    @Enumerated(EnumType.STRING)
     private ProfileImageStatus status;
 
     public void accept() {

--- a/core/domain/src/main/java/org/yapp/core/domain/profile/ProfileImage.java
+++ b/core/domain/src/main/java/org/yapp/core/domain/profile/ProfileImage.java
@@ -1,0 +1,47 @@
+package org.yapp.core.domain.profile;
+
+import org.yapp.core.domain.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProfileImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "profile_image_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "profile_id")
+    private Profile profile;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Column(name = "status")
+    private ProfileImageStatus status;
+
+    public void accept() {
+        this.status = ProfileImageStatus.ACCEPTED;
+        this.profile.updateProfileImageUrl(this.imageUrl);
+    }
+
+    public void reject() {
+        this.status = ProfileImageStatus.REJECTED;
+    }
+}

--- a/core/domain/src/main/java/org/yapp/core/domain/profile/ProfileImageStatus.java
+++ b/core/domain/src/main/java/org/yapp/core/domain/profile/ProfileImageStatus.java
@@ -15,4 +15,3 @@ public enum ProfileImageStatus {
         return displayName;
     }
 }
-s

--- a/core/domain/src/main/java/org/yapp/core/domain/profile/ProfileImageStatus.java
+++ b/core/domain/src/main/java/org/yapp/core/domain/profile/ProfileImageStatus.java
@@ -1,0 +1,17 @@
+package org.yapp.core.domain.profile;
+
+public enum ProfileImageStatus {
+    INCOMPLETE("미완료"),
+    ACCEPTED("통과"),
+    REJECTED("보류");
+
+    private final String displayName;
+
+    ProfileImageStatus(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/core/domain/src/main/java/org/yapp/core/domain/profile/ProfileImageStatus.java
+++ b/core/domain/src/main/java/org/yapp/core/domain/profile/ProfileImageStatus.java
@@ -1,9 +1,9 @@
 package org.yapp.core.domain.profile;
 
 public enum ProfileImageStatus {
-    INCOMPLETE("미완료"),
+    PENDING("심사중"),
     ACCEPTED("통과"),
-    REJECTED("보류");
+    REJECTED("거절");
 
     private final String displayName;
 
@@ -15,3 +15,4 @@ public enum ProfileImageStatus {
         return displayName;
     }
 }
+s

--- a/core/exception/src/main/java/org/yapp/core/exception/error/code/ProfileImageErrorCode.java
+++ b/core/exception/src/main/java/org/yapp/core/exception/error/code/ProfileImageErrorCode.java
@@ -1,0 +1,16 @@
+package org.yapp.core.exception.error.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProfileImageErrorCode implements ErrorCode {
+    PROFILE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필 이미지가 존재하지 않습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-876](https://yapp25app3.atlassian.net/browse/PC-876)

## ✅ 추가사항
### 🔹 API Server

- **ProfileImage 테이블 생성**
  - 사용자가 프로필 생성을 완료한 뒤 시점부터, 변경하는 이미지가 저장되는 테이블입니다.
  - 각 프로필 이미지는 아래의 3가지 상태를 가집니다:
    - `PENDING`
    - `ACCEPTED`
    - `REJECTED`
  - `ProfileBasic` 클래스의 `imageUrl`은 가장 최근에 **승인된 프로필 이미지**라고 생각하면 됩니다.

- **기능 추가**
  - 프로필 이미지 수정 시 Discord Notification 발송
  - 자신의 프로필 Basic 정보 조회 시 `pendingImageUrl` 전달
    - 심사진행 중인 이미지가 있는 경우, 심사 중인 이미지를 함께 전달 (`pendingImageUrl` 필드 포함)

### 🔹 Admin Server

- **프로필 이미지 심사 기능 추가**
- **프로필 이미지 데이터 조회 기능 추가**

## 🔄 수정사항

### 🔹 API Server

- **프로필 이미지 수정 시 Discord Notification 발송**
- **자신의 프로필 Basic 조회 시 `pendingImageUrl` 전달**
  - 심사진행 중인 이미지가 있을 경우, 해당 이미지도 함께 반환
  - 필드명: `pendingImageUrl`

### 🔹 Admin Server

- **사용자 정보 페이지네이션 API에 `profileStatus` 필드 추가**
    
## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항

## 📋 참고 사항
- 코드 리뷰 시 논의가 필요한 사항이나 배포 관련 주의 사항을 추가합니다.


[PC-876]: https://yapp25app3.atlassian.net/browse/PC-876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ