### PR TITLE
[PC-934] fix: 앱 스토어 인증 통과를 위한 SMS 인증 수정

### DIFF
--- a/api/src/main/java/org/yapp/domain/auth/application/authorization/SmsAuthService.java
+++ b/api/src/main/java/org/yapp/domain/auth/application/authorization/SmsAuthService.java
@@ -1,6 +1,7 @@
 package org.yapp.domain.auth.application.authorization;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.yapp.core.exception.ApplicationException;
 import org.yapp.core.exception.error.code.SmsAuthErrorCode;
@@ -15,42 +16,52 @@ import org.yapp.infra.redis.application.RedisService;
 @RequiredArgsConstructor
 public class SmsAuthService {
 
-  private static final long AUTH_CODE_EXPIRE_TIME = 300000;
-  private static final String AUTH_CODE_KEY_PREFIX = "authcode:";
-  private static final String AUTH_CODE_FORMAT = "[PIECE] 인증 번호는 %s 입니다.";
-  private final AuthCodeGenerator authCodeGenerator;
-  private final SmsSenderService smsSenderService;
-  private final RedisService redisService;
+    private static final long AUTH_CODE_EXPIRE_TIME = 300000;
+    private static final String AUTH_CODE_KEY_PREFIX = "authcode:";
+    private static final String AUTH_CODE_FORMAT = "[PIECE] 인증 번호는 %s 입니다.";
+    private final AuthCodeGenerator authCodeGenerator;
+    private final SmsSenderService smsSenderService;
+    private final RedisService redisService;
 
-  /**
-   * 인증번호 전송
-   *
-   * @param phoneNumber 인증 번호를 받을 핸드폰 번호
-   */
-  public SmsAuthResponse sendAuthCodeTo(String phoneNumber) {
+    @Value("${auth.mock-phone-number}")
+    private String mockPhoneNumber;
 
-    String authCode = authCodeGenerator.generate();
-    redisService.setKeyWithExpiration(AUTH_CODE_KEY_PREFIX + phoneNumber, authCode,
-        AUTH_CODE_EXPIRE_TIME);
-    String authCodeMessage = String.format(AUTH_CODE_FORMAT, authCode);
-    smsSenderService.sendSMS(phoneNumber, authCodeMessage);
-    return new SmsAuthResponse(phoneNumber);
-  }
+    @Value("${auth.mock-sms-auth-code}")
+    private String mockSmsAuthCode;
 
-  /**
-   * 인증번호 인증
-   *
-   * @param phoneNumber 핸드폰번호
-   * @param code        인증 번호
-   * @return 인증번호 일치 여부
-   */
-  public void verifySmsAuthCode(String phoneNumber, String code) {
-    String expectedCode = redisService.getValue(AUTH_CODE_KEY_PREFIX + phoneNumber);
-    if (expectedCode == null) {
-      throw new ApplicationException(SmsAuthErrorCode.CODE_NOT_EXIST);
+    /**
+     * 인증번호 전송
+     *
+     * @param phoneNumber 인증 번호를 받을 핸드폰 번호
+     */
+    public SmsAuthResponse sendAuthCodeTo(String phoneNumber) {
+        String authCode = authCodeGenerator.generate();
+
+        if (mockPhoneNumber.equals(phoneNumber)) {
+            authCode = mockSmsAuthCode;
+        }
+
+        redisService.setKeyWithExpiration(AUTH_CODE_KEY_PREFIX + phoneNumber, authCode,
+            AUTH_CODE_EXPIRE_TIME);
+        String authCodeMessage = String.format(AUTH_CODE_FORMAT, authCode);
+        smsSenderService.sendSMS(phoneNumber, authCodeMessage);
+        return new SmsAuthResponse(phoneNumber);
     }
-    if (!expectedCode.equals(code)) {
-      throw new ApplicationException(SmsAuthErrorCode.CODE_NOT_CORRECT);
+
+    /**
+     * 인증번호 인증
+     *
+     * @param phoneNumber 핸드폰번호
+     * @param code        인증 번호
+     * @return 인증번호 일치 여부
+     */
+    public void verifySmsAuthCode(String phoneNumber, String code) {
+        String expectedCode = redisService.getValue(AUTH_CODE_KEY_PREFIX + phoneNumber);
+        if (expectedCode == null) {
+            throw new ApplicationException(SmsAuthErrorCode.CODE_NOT_EXIST);
+        }
+        if (!expectedCode.equals(code)) {
+            throw new ApplicationException(SmsAuthErrorCode.CODE_NOT_CORRECT);
+        }
     }
-  }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-934](https://yapp25app3.atlassian.net/browse/PC-934)

## ✨ 작업 내용
- 앱 스토어 인증 과정 데모를 위한 mock 핸드폰 mock SMS 인증 코드 추가 (.yml)
- mock 핸드폰 번호인 경우 mock SMS 인증 코드를 사용하도록 SMS 인증 로직 변경

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항

## 📋 참고 사항
- 코드 리뷰 시 논의가 필요한 사항이나 배포 관련 주의 사항을 추가합니다.
