### PR TITLE
[PC-964] 어드민 유저 검색 기능 및 FCM 예외 처리 변경

### DIFF
--- a/admin/src/main/java/org/yapp/notification/application/AdminNotificationService.java
+++ b/admin/src/main/java/org/yapp/notification/application/AdminNotificationService.java
@@ -2,7 +2,6 @@ package org.yapp.notification.application;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.yapp.core.domain.notification.enums.NotificationType;
 import org.yapp.core.notification.application.NotificationService;
 import org.yapp.core.notification.dao.FcmTokenRepository;
@@ -14,7 +13,6 @@ public class AdminNotificationService {
     private final NotificationService notificationService;
     private final FcmTokenRepository fcmTokenRepository;
 
-    @Transactional
     public void sendProfileApprovedNotification(Long userId) {
         fcmTokenRepository.findByUserId(userId).ifPresent(fcmToken -> {
             notificationService.sendNotification("fcm", fcmToken.getToken(), userId,
@@ -22,7 +20,6 @@ public class AdminNotificationService {
         });
     }
 
-    @Transactional
     public void sendProfileRejectedNotification(Long userId) {
         fcmTokenRepository.findByUserId(userId).ifPresent(fcmToken -> {
             notificationService.sendNotification("fcm", fcmToken.getToken(), userId,
@@ -30,7 +27,6 @@ public class AdminNotificationService {
         });
     }
 
-    @Transactional
     public void sendProfileImageApprovedNotification(Long userId) {
         fcmTokenRepository.findByUserId(userId).ifPresent(fcmToken -> {
             notificationService.sendNotification("fcm", fcmToken.getToken(), userId,
@@ -39,7 +35,6 @@ public class AdminNotificationService {
         });
     }
 
-    @Transactional
     public void sendProfileImageRejectedNotification(Long userId) {
         fcmTokenRepository.findByUserId(userId).ifPresent(fcmToken -> {
             notificationService.sendNotification("fcm", fcmToken.getToken(), userId,

--- a/admin/src/main/java/org/yapp/profile/application/AdminProfileImageService.java
+++ b/admin/src/main/java/org/yapp/profile/application/AdminProfileImageService.java
@@ -53,11 +53,7 @@ public class AdminProfileImageService {
         User user = getUserByProfileImageId(profileImageId);
 
         profileImage.accept();
-        try {
-            adminNotificationService.sendProfileImageApprovedNotification(user.getId());
-        } catch (ApplicationException e) {
-            log.warn("프로필 이미지 변경 FCM 알림 전송이 실패했습니다.", e);
-        }
+        adminNotificationService.sendProfileImageApprovedNotification(user.getId());
     }
 
     @Transactional
@@ -66,11 +62,7 @@ public class AdminProfileImageService {
         User user = getUserByProfileImageId(profileImageId);
 
         profileImage.reject();
-        try {
-            adminNotificationService.sendProfileImageRejectedNotification(user.getId());
-        } catch (ApplicationException e) {
-            log.warn("프로필 이미지 변경 FCM 알림 전송이 실패했습니다.", e);
-        }
+        adminNotificationService.sendProfileImageRejectedNotification(user.getId());
     }
 
     @Transactional(readOnly = true)

--- a/admin/src/main/java/org/yapp/user/application/UserService.java
+++ b/admin/src/main/java/org/yapp/user/application/UserService.java
@@ -41,6 +41,31 @@ public class UserService {
             .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
     }
 
+    @Transactional(readOnly = true)
+    public UserProfileValidationResponse getUserProfileByUniqueKey(Long userId, Long profileId,
+        String nickname) {
+        User foundUser = null;
+
+        if (userId != null) {
+            foundUser = userRepository.findById(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
+        }
+        if (profileId != null) {
+            foundUser = userRepository.findByProfileId(profileId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
+        }
+        if (nickname != null) {
+            foundUser = userRepository.findByProfileNickname(nickname)
+                .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
+        }
+
+        if (foundUser == null) {
+            throw new ApplicationException(UserErrorCode.NOTFOUND_USER);
+        }
+
+        return convertToValidationResponse(foundUser);
+    }
+
     public Optional<User> getUserByIdIfExists(Long userId) {
         return userRepository.findById(userId);
     }
@@ -50,6 +75,7 @@ public class UserService {
             .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
     }
 
+    @Transactional(readOnly = true)
     public PageResponse<UserProfileValidationResponse> getUserProfilesWithPagination(int page,
         int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
@@ -57,35 +83,7 @@ public class UserService {
         Page<User> userPage = userRepository.findAll(pageable);
 
         List<UserProfileValidationResponse> content = userPage.getContent().stream()
-            .map(user -> {
-                Optional<UserRejectHistory> optionalProfileRejectHistory =
-                    userRejectHistoryRepository.findTopByUserIdOrderByCreatedAtDesc(
-                        user.getId());
-
-                boolean reasonImage = optionalProfileRejectHistory.map(
-                    UserRejectHistory::isReasonImage).orElse(false);
-                boolean reasonDescription = optionalProfileRejectHistory.map(
-                    UserRejectHistory::isReasonDescription).orElse(false);
-
-                Profile profile = user.getProfile();
-                boolean isApproved = profile != null
-                    && profile.getProfileStatus() != null
-                    && profile.getProfileStatus().name().equals("APPROVED");
-
-                ProfileImage profileImage = null;
-                ProfileImageStatus profileImageStatus = null;
-                if (profile != null) {
-                    profileImage = adminProfileImageService.getLatestProfileImageByProfileId(
-                        profile.getId());
-                }
-                if (profileImage != null) {
-                    profileImageStatus = profileImage.getStatus();
-                }
-
-                return UserProfileValidationResponse.from(user,
-                    profileImageStatus, !isApproved && reasonImage,
-                    !isApproved && reasonDescription);
-            })
+            .map(this::convertToValidationResponse)
             .toList();
 
         return new PageResponse<>(
@@ -130,5 +128,35 @@ public class UserService {
 
         return UserProfileImageDetailResponse.from(profileImage,
             profile.getProfileBasic().getImageUrl());
+    }
+
+    private UserProfileValidationResponse convertToValidationResponse(User user) {
+        Optional<UserRejectHistory> optionalProfileRejectHistory =
+            userRejectHistoryRepository.findTopByUserIdOrderByCreatedAtDesc(
+                user.getId());
+
+        boolean reasonImage = optionalProfileRejectHistory.map(
+            UserRejectHistory::isReasonImage).orElse(false);
+        boolean reasonDescription = optionalProfileRejectHistory.map(
+            UserRejectHistory::isReasonDescription).orElse(false);
+
+        Profile profile = user.getProfile();
+        boolean isApproved = profile != null
+            && profile.getProfileStatus() != null
+            && profile.getProfileStatus().name().equals("APPROVED");
+
+        ProfileImage profileImage = null;
+        ProfileImageStatus profileImageStatus = null;
+        if (profile != null) {
+            profileImage = adminProfileImageService.getLatestProfileImageByProfileId(
+                profile.getId());
+        }
+        if (profileImage != null) {
+            profileImageStatus = profileImage.getStatus();
+        }
+
+        return UserProfileValidationResponse.from(user,
+            profileImageStatus, !isApproved && reasonImage,
+            !isApproved && reasonDescription);
     }
 }

--- a/admin/src/main/java/org/yapp/user/dao/UserRepository.java
+++ b/admin/src/main/java/org/yapp/user/dao/UserRepository.java
@@ -2,6 +2,7 @@ package org.yapp.user.dao;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.yapp.core.domain.user.User;
 
@@ -10,5 +11,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findById(Long userId);
 
+    Optional<User> findByProfileId(Long profileId);
+
     Optional<User> findByOauthId(String oauthId);
+
+    @Query("SELECT u FROM User u JOIN u.profile p WHERE p.profileBasic.nickname = :nickname")
+    Optional<User> findByProfileNickname(String nickname);
 }

--- a/admin/src/main/java/org/yapp/user/presentation/UserController.java
+++ b/admin/src/main/java/org/yapp/user/presentation/UserController.java
@@ -39,6 +39,17 @@ public class UserController {
         return ResponseEntity.ok(CommonResponse.createSuccess(userProfilesWithPagination));
     }
 
+
+    @GetMapping("/search")
+    public ResponseEntity<CommonResponse<UserProfileValidationResponse>> searchUser(
+        @RequestParam(required = false) Long userId,
+        @RequestParam(required = false) Long profileId,
+        @RequestParam(required = false) String nickname
+    ) {
+        return ResponseEntity.ok(CommonResponse.createSuccess(
+            userService.getUserProfileByUniqueKey(userId, profileId, nickname)));
+    }
+
     @GetMapping("/{userId}")
     public ResponseEntity<CommonResponse<UserProfileDetailResponses>> getUserProfile(
         @PathVariable Long userId) {

--- a/api/src/main/java/org/yapp/domain/user/presentation/dto/request/OauthUserDeleteRequest.java
+++ b/api/src/main/java/org/yapp/domain/user/presentation/dto/request/OauthUserDeleteRequest.java
@@ -14,8 +14,8 @@ public class OauthUserDeleteRequest {
 
     @NotNull(message = "providerName은 null일 수 없습니다.")
     @Pattern(
-        regexp = "^(apple|kakako|google)$",
-        message = "providerName은 apple, kakako, google 중 하나여야 합니다."
+        regexp = "^(apple|kakao|google)$",
+        message = "providerName은 apple, kakao, google 중 하나여야 합니다."
     )
     private String providerName;
     private String oauthCredential;

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    include: db, secret, devtool, s3, sms, redis, ai
+    include: db, secret, devtool, s3, sms, redis, ai, discord

--- a/core/notification/src/main/java/org/yapp/core/notification/application/NotificationService.java
+++ b/core/notification/src/main/java/org/yapp/core/notification/application/NotificationService.java
@@ -4,7 +4,9 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.yapp.core.domain.notification.NotificationHistory;
 import org.yapp.core.domain.notification.enums.NotificationType;
@@ -14,34 +16,37 @@ import org.yapp.core.notification.provider.NotificationProvider;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class NotificationService {
 
-  private final NotificationProvider notificationProvider;
-  private final NotificationHistoryRepository notificationHistoryRepository;
+    private final NotificationProvider notificationProvider;
+    private final NotificationHistoryRepository notificationHistoryRepository;
 
-  @Transactional
-  public void sendNotification(String clientName, String token, Long userId,
-      NotificationType notificationType, String title, String body) {
-    Map<String, String> data = new HashMap<>();
-    NotificationClient notificationClient = notificationProvider.getNotificationClient(
-        clientName);
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void sendNotification(String clientName, String token, Long userId,
+        NotificationType notificationType, String title, String body) {
+        Map<String, String> data = new HashMap<>();
+        NotificationClient notificationClient = notificationProvider.getNotificationClient(
+            clientName);
 
-    NotificationHistory notificationHistory = NotificationHistory.builder()
-        .userId(userId)
-        .notificationType(notificationType)
-        .title(title)
-        .body(body)
-        .isRead(false)
-        .dateTime(LocalDateTime.now())
-        .build();
+        NotificationHistory notificationHistory = NotificationHistory.builder()
+            .userId(userId)
+            .notificationType(notificationType)
+            .title(title)
+            .body(body)
+            .isRead(false)
+            .dateTime(LocalDateTime.now())
+            .build();
 
-    NotificationHistory newNotificationHistory = notificationHistoryRepository.save(
-        notificationHistory);
-    data.put("notificationId", String.valueOf(newNotificationHistory.getId()));
+        NotificationHistory newNotificationHistory = notificationHistoryRepository.save(
+            notificationHistory);
+        data.put("notificationId", String.valueOf(newNotificationHistory.getId()));
 
-    notificationClient.sendNotificationWithData(token, title, body, data);
-  }
-
-
+        try {
+            notificationClient.sendNotificationWithData(token, title, body, data);
+        } catch (Exception e) {
+            log.warn("FCM 전송 실패: userId={}, token={}", userId, token, e);
+        }
+    }
 }
 

--- a/core/notification/src/main/java/org/yapp/core/notification/application/NotificationService.java
+++ b/core/notification/src/main/java/org/yapp/core/notification/application/NotificationService.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.yapp.core.domain.notification.NotificationHistory;
 import org.yapp.core.domain.notification.enums.NotificationType;
@@ -22,7 +21,7 @@ public class NotificationService {
     private final NotificationProvider notificationProvider;
     private final NotificationHistoryRepository notificationHistoryRepository;
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional()
     public void sendNotification(String clientName, String token, Long userId,
         NotificationType notificationType, String title, String body) {
         Map<String, String> data = new HashMap<>();


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-964](https://yapp25app3.atlassian.net/browse/PC-964)

## ✨ 작업 내용
- 유저 ID, 프로필 ID, 닉네임으로 유저 조회
- NotificationService#sendNotification 
   - 트랜잭션 전파 설정 변경 (Propagation.REQUIRES_NEW)
   - FCM 에외 발생을 외부로 전파시키지 않도록 설정

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항

## 📋 참고 사항
- 코드 리뷰 시 논의가 필요한 사항이나 배포 관련 주의 사항을 추가합니다.


[PC-964]: https://yapp25app3.atlassian.net/browse/PC-964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ