### PR TITLE
[PC-1007] 유저 정보 API에서 role 변경시 토큰 재발급

### DIFF
--- a/api/src/main/java/org/yapp/domain/user/application/UserService.java
+++ b/api/src/main/java/org/yapp/domain/user/application/UserService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.yapp.core.auth.AuthToken;
 import org.yapp.core.auth.AuthTokenGenerator;
+import org.yapp.core.auth.AuthUtil;
 import org.yapp.core.auth.dao.BannedUserPhoneNumberRepository;
 import org.yapp.core.auth.jwt.JwtUtil;
 import org.yapp.core.domain.fcm.FcmToken;
@@ -31,8 +32,6 @@ import org.yapp.domain.user.presentation.dto.response.UserRejectHistoryResponse;
 @Service
 @RequiredArgsConstructor
 public class UserService {
-
-    private static int BEARER_PREFIX_LENGTH = 7;
 
     private final UserRepository userRepository;
     private final UserRejectHistoryRepository userRejectHistoryRepository;
@@ -131,7 +130,7 @@ public class UserService {
         String profileStatus =
             profile != null ? profile.getProfileStatus().toString() : null;
 
-        String accessToken = extractAccessToken(authorizationHeader);
+        String accessToken = AuthUtil.extractAccessToken(authorizationHeader);
         String accessTokenRole = jwtUtil.getRole(accessToken);
         String userRole = user.getRole();
 
@@ -145,9 +144,6 @@ public class UserService {
         return new UserBasicInfoResponse(userId, userRole, profileStatus, false, null, null);
     }
 
-    private static String extractAccessToken(String authorizationHeader) {
-        return authorizationHeader.substring(BEARER_PREFIX_LENGTH);
-    }
 
     @Transactional
     public void saveFcmToken(Long userId, FcmTokenSaveRequest request) {

--- a/api/src/main/java/org/yapp/domain/user/application/UserService.java
+++ b/api/src/main/java/org/yapp/domain/user/application/UserService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.yapp.core.auth.AuthToken;
 import org.yapp.core.auth.AuthTokenGenerator;
 import org.yapp.core.auth.dao.BannedUserPhoneNumberRepository;
+import org.yapp.core.auth.jwt.JwtUtil;
 import org.yapp.core.domain.fcm.FcmToken;
 import org.yapp.core.domain.profile.Profile;
 import org.yapp.core.domain.user.RoleStatus;
@@ -31,139 +32,152 @@ import org.yapp.domain.user.presentation.dto.response.UserRejectHistoryResponse;
 @RequiredArgsConstructor
 public class UserService {
 
-  private final UserRepository userRepository;
-  private final UserRejectHistoryRepository userRejectHistoryRepository;
-  private final UserDeleteReasonRepository userDeleteReasonRepository;
-  private final AuthTokenGenerator authTokenGenerator;
-  private final FcmTokenRepository fcmTokenRepository;
-  private final BannedUserPhoneNumberRepository bannedUserPhoneNumberRepository;
+    private final UserRepository userRepository;
+    private final UserRejectHistoryRepository userRejectHistoryRepository;
+    private final UserDeleteReasonRepository userDeleteReasonRepository;
+    private final AuthTokenGenerator authTokenGenerator;
+    private final FcmTokenRepository fcmTokenRepository;
+    private final BannedUserPhoneNumberRepository bannedUserPhoneNumberRepository;
+    private final JwtUtil jwtUtil;
 
-  /**
-   * Role을 USER로 바꾸고 변경된 토큰을 반환한다.
-   *
-   * @return 액세스토큰과 리프레시 토큰
-   */
-  @Transactional
-  public OauthLoginResponse completeProfileInitialize(Long userId, Profile profile) {
-    User user =
-        userRepository.findById(userId)
+    /**
+     * Role을 USER로 바꾸고 변경된 토큰을 반환한다.
+     *
+     * @return 액세스토큰과 리프레시 토큰
+     */
+    @Transactional
+    public OauthLoginResponse completeProfileInitialize(Long userId, Profile profile) {
+        User user =
+            userRepository.findById(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
+        user.setProfile(profile);
+        user.updateUserRole(RoleStatus.PENDING.getStatus());
+        String oauthId = user.getOauthId();
+        AuthToken authToken = authTokenGenerator.generate(userId, oauthId, user.getRole());
+        return new OauthLoginResponse(RoleStatus.PENDING.getStatus(), authToken.accessToken(),
+            authToken.refreshToken());
+    }
+
+    public User getUserById(Long userId) {
+        return userRepository.findById(userId)
             .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
-    user.setProfile(profile);
-    user.updateUserRole(RoleStatus.PENDING.getStatus());
-    String oauthId = user.getOauthId();
-    AuthToken authToken = authTokenGenerator.generate(userId, oauthId, user.getRole());
-    return new OauthLoginResponse(RoleStatus.PENDING.getStatus(), authToken.accessToken(),
-        authToken.refreshToken());
-  }
-
-  public User getUserById(Long userId) {
-    return userRepository.findById(userId)
-        .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
-  }
-
-  /**
-   * Role을 Register로 바꾸고 변경된 토큰을 반환한다.
-   *
-   * @return 액세스토큰과 리프레시 토큰
-   */
-  @Transactional
-  public SmsVerifyResponse registerPhoneNumber(Long userId, String phoneNumber) {
-    Optional<User> userOptionalByPhoneNumber = this.getUserByPhoneNumber(phoneNumber);
-
-    // 이미 가입한 유저
-    if (userOptionalByPhoneNumber.isPresent()) {
-      String userOauthProvider = this.getUserOauthProvider(
-          userOptionalByPhoneNumber.get().getOauthId());
-
-      return new SmsVerifyResponse(null, null, null, true, userOauthProvider);
     }
 
-    // 정지된 유저가 기존 계정 삭제하고 다시 가입하려고 할 때 방지
-    if (bannedUserPhoneNumberRepository.findById(phoneNumber).isPresent()) {
-      throw new ApplicationException(AuthErrorCode.PERMANENTLY_BANNED);
+    /**
+     * Role을 Register로 바꾸고 변경된 토큰을 반환한다.
+     *
+     * @return 액세스토큰과 리프레시 토큰
+     */
+    @Transactional
+    public SmsVerifyResponse registerPhoneNumber(Long userId, String phoneNumber) {
+        Optional<User> userOptionalByPhoneNumber = this.getUserByPhoneNumber(phoneNumber);
+
+        // 이미 가입한 유저
+        if (userOptionalByPhoneNumber.isPresent()) {
+            String userOauthProvider = this.getUserOauthProvider(
+                userOptionalByPhoneNumber.get().getOauthId());
+
+            return new SmsVerifyResponse(null, null, null, true, userOauthProvider);
+        }
+
+        // 정지된 유저가 기존 계정 삭제하고 다시 가입하려고 할 때 방지
+        if (bannedUserPhoneNumberRepository.findById(phoneNumber).isPresent()) {
+            throw new ApplicationException(AuthErrorCode.PERMANENTLY_BANNED);
+        }
+
+        User user =
+            userRepository.findById(userId)
+                .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
+
+        user.updateUserRole(RoleStatus.REGISTER.getStatus());
+        user.initializePhoneNumber(phoneNumber);
+        String oauthId = user.getOauthId();
+        AuthToken authToken = authTokenGenerator.generate(userId, oauthId, user.getRole());
+        return new SmsVerifyResponse(RoleStatus.REGISTER.getStatus(), authToken.accessToken(),
+            authToken.refreshToken(), false, null);
     }
 
-    User user =
-        userRepository.findById(userId)
-            .orElseThrow(() -> new ApplicationException(UserErrorCode.NOTFOUND_USER));
+    @Transactional(readOnly = true)
+    public UserRejectHistoryResponse getUserRejectHistoryLatest(Long userId) {
+        boolean reasonImage = false;
+        boolean reasonDescription = false;
 
-    user.updateUserRole(RoleStatus.REGISTER.getStatus());
-    user.initializePhoneNumber(phoneNumber);
-    String oauthId = user.getOauthId();
-    AuthToken authToken = authTokenGenerator.generate(userId, oauthId, user.getRole());
-    return new SmsVerifyResponse(RoleStatus.REGISTER.getStatus(), authToken.accessToken(),
-        authToken.refreshToken(), false, null);
-  }
+        UserRejectHistory userRejectHistory = userRejectHistoryRepository.findTopByUserIdOrderByCreatedAtDesc(
+            userId).orElse(null);
 
-  @Transactional(readOnly = true)
-  public UserRejectHistoryResponse getUserRejectHistoryLatest(Long userId) {
-    boolean reasonImage = false;
-    boolean reasonDescription = false;
+        if (userRejectHistory != null) {
+            reasonImage = userRejectHistory.isReasonImage();
+            reasonDescription = userRejectHistory.isReasonDescription();
+        }
 
-    UserRejectHistory userRejectHistory = userRejectHistoryRepository.findTopByUserIdOrderByCreatedAtDesc(
-        userId).orElse(null);
-
-    if (userRejectHistory != null) {
-      reasonImage = userRejectHistory.isReasonImage();
-      reasonDescription = userRejectHistory.isReasonDescription();
+        return new UserRejectHistoryResponse(
+            reasonImage,
+            reasonDescription
+        );
     }
 
-    return new UserRejectHistoryResponse(
-        reasonImage,
-        reasonDescription
-    );
-  }
-
-  @Transactional
-  public void deleteUser(Long userId, String reason) {
-    userDeleteReasonRepository.save(new UserDeleteReason(userId, reason));
-    userRepository.deleteById(userId);
-  }
-
-  public UserBasicInfoResponse getUserBasicInfo(Long userId) {
-    User user = this.getUserById(userId);
-
-    Profile profile = user.getProfile();
-    String profileStatus =
-        profile != null ? profile.getProfileStatus().toString() : null;
-
-    return new UserBasicInfoResponse(userId, user.getRole(), profileStatus);
-  }
-
-  @Transactional
-  public void saveFcmToken(Long userId, FcmTokenSaveRequest request) {
-    Optional<FcmToken> fcmTokenOptional = fcmTokenRepository.findByUserId(userId);
-    if (fcmTokenOptional.isPresent()) {
-      FcmToken fcmToken = fcmTokenOptional.get();
-      fcmToken.updateToken(request.getToken());
-    } else {
-      FcmToken fcmToken = new FcmToken(userId, request.getToken());
-      fcmTokenRepository.save(fcmToken);
+    @Transactional
+    public void deleteUser(Long userId, String reason) {
+        userDeleteReasonRepository.save(new UserDeleteReason(userId, reason));
+        userRepository.deleteById(userId);
     }
-  }
 
-  @Transactional
-  public void deleteFcmToken(Long userId) {
-    fcmTokenRepository.deleteByUserId(userId);
-  }
+    public UserBasicInfoResponse getUserBasicInfo(Long userId, String authorizationHeader) {
+        User user = this.getUserById(userId);
 
-  public Optional<User> getUserByPhoneNumber(String phoneNumber) {
-    return userRepository.findByPhoneNumber(phoneNumber);
-  }
+        Profile profile = user.getProfile();
+        String profileStatus =
+            profile != null ? profile.getProfileStatus().toString() : null;
 
-  public String getUserOauthProvider(String oauthId) {
-    if (oauthId.startsWith("kakao")) {
-      return "kakao";
-    } else if (oauthId.startsWith("apple")) {
-      return "apple";
-    } else if (oauthId.startsWith("google")) {
-      return "google";
-    } else {
-      throw new ApplicationException(UserErrorCode.INVALID_OAUTH_PROVIDER);
+        String accessToken = authorizationHeader.substring(7);
+        String accessTokenRole = jwtUtil.getRole(accessToken);
+        String userRole = user.getRole();
+
+        if (!accessTokenRole.equals(userRole)) {
+            AuthToken authToken = authTokenGenerator.generate(userId, user.getOauthId(),
+                user.getRole());
+            return new UserBasicInfoResponse(userId, userRole, profileStatus, true,
+                authToken.accessToken(), authToken.refreshToken());
+        }
+
+        return new UserBasicInfoResponse(userId, userRole, profileStatus, false, null, null);
+
     }
-  }
 
-  public List<User> getAllUsers() {
-    return userRepository.findAll();
-  }
+    @Transactional
+    public void saveFcmToken(Long userId, FcmTokenSaveRequest request) {
+        Optional<FcmToken> fcmTokenOptional = fcmTokenRepository.findByUserId(userId);
+        if (fcmTokenOptional.isPresent()) {
+            FcmToken fcmToken = fcmTokenOptional.get();
+            fcmToken.updateToken(request.getToken());
+        } else {
+            FcmToken fcmToken = new FcmToken(userId, request.getToken());
+            fcmTokenRepository.save(fcmToken);
+        }
+    }
+
+    @Transactional
+    public void deleteFcmToken(Long userId) {
+        fcmTokenRepository.deleteByUserId(userId);
+    }
+
+    public Optional<User> getUserByPhoneNumber(String phoneNumber) {
+        return userRepository.findByPhoneNumber(phoneNumber);
+    }
+
+    public String getUserOauthProvider(String oauthId) {
+        if (oauthId.startsWith("kakao")) {
+            return "kakao";
+        } else if (oauthId.startsWith("apple")) {
+            return "apple";
+        } else if (oauthId.startsWith("google")) {
+            return "google";
+        } else {
+            throw new ApplicationException(UserErrorCode.INVALID_OAUTH_PROVIDER);
+        }
+    }
+
+    public List<User> getAllUsers() {
+        return userRepository.findAll();
+    }
 }

--- a/api/src/main/java/org/yapp/domain/user/application/UserService.java
+++ b/api/src/main/java/org/yapp/domain/user/application/UserService.java
@@ -32,6 +32,8 @@ import org.yapp.domain.user.presentation.dto.response.UserRejectHistoryResponse;
 @RequiredArgsConstructor
 public class UserService {
 
+    private static int BEARER_PREFIX_LENGTH = 7;
+
     private final UserRepository userRepository;
     private final UserRejectHistoryRepository userRejectHistoryRepository;
     private final UserDeleteReasonRepository userDeleteReasonRepository;
@@ -129,7 +131,7 @@ public class UserService {
         String profileStatus =
             profile != null ? profile.getProfileStatus().toString() : null;
 
-        String accessToken = authorizationHeader.substring(7);
+        String accessToken = extractAccessToken(authorizationHeader);
         String accessTokenRole = jwtUtil.getRole(accessToken);
         String userRole = user.getRole();
 
@@ -141,7 +143,10 @@ public class UserService {
         }
 
         return new UserBasicInfoResponse(userId, userRole, profileStatus, false, null, null);
+    }
 
+    private static String extractAccessToken(String authorizationHeader) {
+        return authorizationHeader.substring(BEARER_PREFIX_LENGTH);
     }
 
     @Transactional

--- a/api/src/main/java/org/yapp/domain/user/presentation/UserController.java
+++ b/api/src/main/java/org/yapp/domain/user/presentation/UserController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.yapp.domain.auth.application.oauth.service.OauthService;
@@ -27,58 +28,60 @@ import org.yapp.format.CommonResponse;
 @RequestMapping("/api/users")
 public class UserController {
 
-  private final UserService userService;
-  private final OauthService oauthService;
+    private final UserService userService;
+    private final OauthService oauthService;
 
-  @GetMapping("/reject")
-  @PreAuthorize(value = "hasAnyAuthority('PENDING')")
-  @Operation(summary = "사용자 거절 사유 조회", description = "사용자의 최근 거절 사유를 조회합니다.", tags = {"사용자"})
-  public ResponseEntity<CommonResponse<UserRejectHistoryResponse>> getUserRejectHistory(
-      @AuthenticationPrincipal Long userId) {
-    UserRejectHistoryResponse response = userService.getUserRejectHistoryLatest(
-        userId);
+    @GetMapping("/reject")
+    @PreAuthorize(value = "hasAnyAuthority('PENDING')")
+    @Operation(summary = "사용자 거절 사유 조회", description = "사용자의 최근 거절 사유를 조회합니다.", tags = {"사용자"})
+    public ResponseEntity<CommonResponse<UserRejectHistoryResponse>> getUserRejectHistory(
+        @AuthenticationPrincipal Long userId) {
+        UserRejectHistoryResponse response = userService.getUserRejectHistoryLatest(
+            userId);
 
-    return ResponseEntity.status(HttpStatus.OK)
-        .body(CommonResponse.createSuccess(response));
-  }
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(CommonResponse.createSuccess(response));
+    }
 
-  @DeleteMapping
-  @PreAuthorize(value = "hasAnyAuthority('REGISTER','PENDING','USER')")
-  @Operation(summary = "회원 탈퇴", description = "회원 탈퇴합니다.", tags = {"사용자"})
-  public ResponseEntity<CommonResponse<Void>> deleteUser(
-      @RequestBody @Valid UserDeleteRequest request,
-      @AuthenticationPrincipal Long userId) {
-    userService.deleteUser(userId, request.getReason());
-    return ResponseEntity.ok(CommonResponse.createSuccessWithNoContent());
-  }
+    @DeleteMapping
+    @PreAuthorize(value = "hasAnyAuthority('REGISTER','PENDING','USER')")
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴합니다.", tags = {"사용자"})
+    public ResponseEntity<CommonResponse<Void>> deleteUser(
+        @RequestBody @Valid UserDeleteRequest request,
+        @AuthenticationPrincipal Long userId) {
+        userService.deleteUser(userId, request.getReason());
+        return ResponseEntity.ok(CommonResponse.createSuccessWithNoContent());
+    }
 
-  @DeleteMapping("/oauth")
-  @PreAuthorize(value = "hasAnyAuthority('REGISTER','PENDING','USER')")
-  @Operation(summary = "회원 탈퇴", description = "회원 탈퇴합니다.", tags = {"사용자"})
-  public ResponseEntity<CommonResponse<Void>> deleteUser(
-      @RequestBody @Valid OauthUserDeleteRequest request,
-      @AuthenticationPrincipal Long userId) {
+    @DeleteMapping("/oauth")
+    @PreAuthorize(value = "hasAnyAuthority('REGISTER','PENDING','USER')")
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴합니다.", tags = {"사용자"})
+    public ResponseEntity<CommonResponse<Void>> deleteUser(
+        @RequestBody @Valid OauthUserDeleteRequest request,
+        @AuthenticationPrincipal Long userId) {
 
-    oauthService.withdraw(request, userId);
-    return ResponseEntity.ok(CommonResponse.createSuccessWithNoContent());
-  }
+        oauthService.withdraw(request, userId);
+        return ResponseEntity.ok(CommonResponse.createSuccessWithNoContent());
+    }
 
-  @GetMapping("/info")
-  @PreAuthorize(value = "isAuthenticated()")
-  @Operation(summary = "회원 기본정보 확인", description = "회원의 기본 정보를 확인합니다", tags = {"사용자"})
-  public ResponseEntity<CommonResponse<UserBasicInfoResponse>> getUserBasicInfo(
-      @AuthenticationPrincipal Long userId) {
-    UserBasicInfoResponse userBasicInfo = userService.getUserBasicInfo(userId);
-    return ResponseEntity.ok(CommonResponse.createSuccess(userBasicInfo));
-  }
+    @GetMapping("/info")
+    @PreAuthorize(value = "isAuthenticated()")
+    @Operation(summary = "회원 기본정보 확인", description = "회원의 기본 정보를 확인합니다", tags = {"사용자"})
+    public ResponseEntity<CommonResponse<UserBasicInfoResponse>> getUserBasicInfo(
+        @AuthenticationPrincipal Long userId,
+        @RequestHeader("Authorization") String authorizationHeader) {
+        UserBasicInfoResponse userBasicInfo =
+            userService.getUserBasicInfo(userId, authorizationHeader);
+        return ResponseEntity.ok(CommonResponse.createSuccess(userBasicInfo));
+    }
 
-  @PostMapping("/fcm-token")
-  @PreAuthorize(value = "isAuthenticated()")
-  @Operation(summary = "FCM 토큰 등록", description = "FCM 토큰을 등록합니다", tags = {"사용자"})
-  public ResponseEntity<CommonResponse<Void>> saveFcmToken(
-      @AuthenticationPrincipal Long userId,
-      @RequestBody FcmTokenSaveRequest request) {
-    userService.saveFcmToken(userId, request);
-    return ResponseEntity.ok(CommonResponse.createSuccessWithNoContent());
-  }
+    @PostMapping("/fcm-token")
+    @PreAuthorize(value = "isAuthenticated()")
+    @Operation(summary = "FCM 토큰 등록", description = "FCM 토큰을 등록합니다", tags = {"사용자"})
+    public ResponseEntity<CommonResponse<Void>> saveFcmToken(
+        @AuthenticationPrincipal Long userId,
+        @RequestBody FcmTokenSaveRequest request) {
+        userService.saveFcmToken(userId, request);
+        return ResponseEntity.ok(CommonResponse.createSuccessWithNoContent());
+    }
 }

--- a/api/src/main/java/org/yapp/domain/user/presentation/dto/response/UserBasicInfoResponse.java
+++ b/api/src/main/java/org/yapp/domain/user/presentation/dto/response/UserBasicInfoResponse.java
@@ -1,6 +1,11 @@
 package org.yapp.domain.user.presentation.dto.response;
 
 
-public record UserBasicInfoResponse(Long userId, String role, String profileStatus) {
+public record UserBasicInfoResponse(Long userId,
+                                    String role,
+                                    String profileStatus,
+                                    Boolean hasRoleChanged,
+                                    String accessToken,
+                                    String refreshToken) {
 
 }

--- a/core/auth/src/main/java/org/yapp/core/auth/AuthUtil.java
+++ b/core/auth/src/main/java/org/yapp/core/auth/AuthUtil.java
@@ -1,0 +1,10 @@
+package org.yapp.core.auth;
+
+public class AuthUtil {
+
+    private static int BEARER_PREFIX_LENGTH = 7;
+
+    public static String extractAccessToken(String authorizationHeader) {
+        return authorizationHeader.substring(BEARER_PREFIX_LENGTH);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-1007]
## ✨ 작업 내용
- 토큰 내부의 role과 유저 role의 불일치를 해결하기 위해 user info 조회에서 role 변경을 알 수 있도록 필드를 추가하였습니다.
- 클라이언트 측의 요청에 따라 role 불일치가 발생했을 때 user info API에서 바로 role이 갱신된 jwtToken을 반환하도록 필드를 추가하였습니다.
## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항

## 📋 참고 사항
- 코드 리뷰 시 논의가 필요한 사항이나 배포 관련 주의 사항을 추가합니다.


[PC-1007]: https://yapp25app3.atlassian.net/browse/PC-1007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ