### PR TITLE
[PC-1136] 매칭 설정 필드 삭제

### DIFF
--- a/api/src/main/java/org/yapp/domain/setting/application/SettingService.java
+++ b/api/src/main/java/org/yapp/domain/setting/application/SettingService.java
@@ -61,8 +61,8 @@ public class SettingService {
 
     public SettingInfoResponse getUserSettingInfo(Long userId) {
         Setting userSetting = getUserSetting(userId);
-        return new SettingInfoResponse(userSetting.isNotification(),
-            userSetting.isMatchNotification(),
+        return new SettingInfoResponse(
+            userSetting.isNotification(),
             userSetting.isAcquaintanceBlock());
     }
 }

--- a/api/src/main/java/org/yapp/domain/setting/dto/response/SettingInfoResponse.java
+++ b/api/src/main/java/org/yapp/domain/setting/dto/response/SettingInfoResponse.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class SettingInfoResponse {
 
-  private Boolean isNotificationEnabled;
-  private Boolean isMatchNotificationEnabled;
-  private Boolean isAcquaintanceBlockEnabled;
+    private Boolean isNotificationEnabled;
+    private Boolean isAcquaintanceBlockEnabled;
 }


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-1136]
## ✨ 작업 내용
- 매칭 설정 필드 삭제했습니다.
## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] Label을 지정했나요?
- [x] merge할 브랜치의 위치를 확인했나요?

[PC-1136]: https://yapp25app3.atlassian.net/browse/PC-1136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ