### PR TITLE
[PC-1179] 프로모션 상품 조회

### DIFF
--- a/api/src/main/java/org/yapp/domain/cashProduct/presentation/CashProductController.java
+++ b/api/src/main/java/org/yapp/domain/cashProduct/presentation/CashProductController.java
@@ -5,12 +5,15 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.yapp.domain.cashProduct.application.dto.CashProductQueryResult;
 import org.yapp.domain.cashProduct.application.query.CashProductQueryService;
 import org.yapp.domain.cashProduct.presentation.dto.response.CashProductResponses;
+import org.yapp.domain.promotion.application.dto.PromotionCashProductQueryResult;
+import org.yapp.domain.promotion.application.query.PromotionCashProductQueryService;
 import org.yapp.format.CommonResponse;
 
 @RestController
@@ -19,13 +22,20 @@ import org.yapp.format.CommonResponse;
 public class CashProductController {
 
     private final CashProductQueryService cashProductQueryService;
+    private final PromotionCashProductQueryService promotionCashProductQueryService;
 
     @GetMapping
     @Operation(summary = "현금 결제 상품 조회", description = "구매 가능한 현금 상품을 모두 조회합니다.", tags = {"현금 상품"})
-    public ResponseEntity<CommonResponse<CashProductResponses>> getCashProducts() {
+    public ResponseEntity<CommonResponse<CashProductResponses>> getCashProducts(
+        @AuthenticationPrincipal Long userId) {
         List<CashProductQueryResult> cashProductQueryResults = cashProductQueryService.getCashProductsIsActive();
+        List<PromotionCashProductQueryResult> promotionCashProductQueryResults = promotionCashProductQueryService
+            .getPromotionCashProductsByUserId(
+                userId);
 
         return ResponseEntity.status(HttpStatus.OK)
-            .body(CommonResponse.createSuccess(CashProductResponses.from(cashProductQueryResults)));
+            .body(CommonResponse.createSuccess(
+                CashProductResponses.from(cashProductQueryResults,
+                    promotionCashProductQueryResults)));
     }
 }

--- a/api/src/main/java/org/yapp/domain/cashProduct/presentation/dto/response/CashProductResponses.java
+++ b/api/src/main/java/org/yapp/domain/cashProduct/presentation/dto/response/CashProductResponses.java
@@ -2,15 +2,24 @@ package org.yapp.domain.cashProduct.presentation.dto.response;
 
 import java.util.List;
 import org.yapp.domain.cashProduct.application.dto.CashProductQueryResult;
+import org.yapp.domain.promotion.application.dto.PromotionCashProductQueryResult;
+import org.yapp.domain.promotion.presentation.dto.response.PromotionCashProductResponse;
 
-public record CashProductResponses(List<CashProductResponse> responses) {
+public record CashProductResponses(
+        List<CashProductResponse> basicCashProducts,
+        List<PromotionCashProductResponse> promotionCashProducts) {
 
-    public static CashProductResponses from(List<CashProductQueryResult> cashProductsDto) {
-        List<CashProductResponse> responses =
-            cashProductsDto.stream()
+    public static CashProductResponses from(
+            List<CashProductQueryResult> cashProductsDto,
+            List<PromotionCashProductQueryResult> promotionCashProductsDto) {
+        List<CashProductResponse> basicCashProductResponses = cashProductsDto.stream()
                 .map(CashProductResponse::from)
                 .toList();
 
-        return new CashProductResponses(responses);
+        List<PromotionCashProductResponse> promotionCashProductResponses = promotionCashProductsDto.stream()
+                .map(PromotionCashProductResponse::from)
+                .toList();
+
+        return new CashProductResponses(basicCashProductResponses, promotionCashProductResponses);
     }
 }

--- a/api/src/main/java/org/yapp/domain/payment/application/PaymentHistoryService.java
+++ b/api/src/main/java/org/yapp/domain/payment/application/PaymentHistoryService.java
@@ -1,0 +1,25 @@
+package org.yapp.domain.payment.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.yapp.core.domain.user.User;
+import org.yapp.domain.payment.dao.PaymentRepository;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentHistoryService {
+
+    private final PaymentRepository paymentRepository;
+
+    @Transactional(readOnly = true)
+    public boolean hasAnyPaymentHistory(User user) {
+        return paymentRepository.existsByUser(user);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean hasAnyPaymentHistory(Long userId) {
+        User user = User.builder().id(userId).build();
+        return hasAnyPaymentHistory(user);
+    }
+}

--- a/api/src/main/java/org/yapp/domain/payment/dao/InAppPaymentRepository.java
+++ b/api/src/main/java/org/yapp/domain/payment/dao/InAppPaymentRepository.java
@@ -9,5 +9,4 @@ import org.yapp.core.domain.payment.inApp.entity.InAppPayment;
 public interface InAppPaymentRepository extends JpaRepository<InAppPayment, Long> {
 
     Optional<InAppPayment> findByPurchaseId(String purchaseId);
-
 }

--- a/api/src/main/java/org/yapp/domain/payment/dao/PaymentRepository.java
+++ b/api/src/main/java/org/yapp/domain/payment/dao/PaymentRepository.java
@@ -1,0 +1,12 @@
+package org.yapp.domain.payment.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.yapp.core.domain.payment.common.entity.Payment;
+import org.yapp.core.domain.user.User;
+
+@Repository
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    
+    boolean existsByUser(User user);
+}

--- a/api/src/main/java/org/yapp/domain/promotion/application/dto/PromotionCashProductQueryResult.java
+++ b/api/src/main/java/org/yapp/domain/promotion/application/dto/PromotionCashProductQueryResult.java
@@ -1,0 +1,29 @@
+package org.yapp.domain.promotion.application.dto;
+
+import java.math.BigDecimal;
+import org.yapp.core.domain.common.vo.Money;
+import org.yapp.core.domain.common.vo.Puzzle;
+import org.yapp.core.domain.promotion.PromotionCashProduct;
+
+public record PromotionCashProductQueryResult(
+    Long id,
+    String uuid,
+    String name,
+    Money price,
+    BigDecimal discountRate,
+    Boolean isActive,
+    Puzzle rewardPuzzle,
+    String cardImageUrl) {
+
+    public static PromotionCashProductQueryResult from(PromotionCashProduct promotionCashProduct) {
+        return new PromotionCashProductQueryResult(
+            promotionCashProduct.getId(),
+            promotionCashProduct.getUuid(),
+            promotionCashProduct.getName(),
+            promotionCashProduct.getPrice(),
+            promotionCashProduct.getDiscountRate(),
+            promotionCashProduct.getIsActive(),
+            promotionCashProduct.getRewardPuzzle(),
+            promotionCashProduct.getCardImageUrl());
+    }
+}

--- a/api/src/main/java/org/yapp/domain/promotion/application/query/PromotionCashProductQueryService.java
+++ b/api/src/main/java/org/yapp/domain/promotion/application/query/PromotionCashProductQueryService.java
@@ -1,0 +1,48 @@
+package org.yapp.domain.promotion.application.query;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.yapp.core.domain.promotion.PromotionCashProduct;
+import org.yapp.core.domain.user.User;
+import org.yapp.domain.promotion.application.dto.PromotionCashProductQueryResult;
+import org.yapp.domain.promotion.application.query.promotionValid.PromotionValidator;
+import org.yapp.domain.promotion.dao.PromotionCashProductRepository;
+
+@Service
+@RequiredArgsConstructor
+public class PromotionCashProductQueryService {
+
+    private final PromotionCashProductRepository promotionCashProductRepository;
+    private final PromotionValidator promotionValidator;
+
+    @Transactional(readOnly = true)
+    public List<PromotionCashProductQueryResult> getPromotionCashProductsByUserId(Long userId) {
+        List<PromotionCashProduct> promotionCashProducts = getPromotionCashProducts();
+
+        return promotionCashProducts.stream()
+            .filter(promotionCashProduct -> this.checkUserAppliedPromotion(userId,
+                promotionCashProduct))
+            .map(
+                PromotionCashProductQueryResult::from
+            ).collect(Collectors.toList());
+    }
+
+    private List<PromotionCashProduct> getPromotionCashProducts() {
+        return promotionCashProductRepository.findAllByStartDateBeforeAndEndDateAfterAndIsActive(
+            LocalDate.now(),
+            LocalDate.now(), true);
+    }
+
+    private boolean checkUserAppliedPromotion(Long userId,
+        PromotionCashProduct promotionCashProduct) {
+        User user = User.builder()
+            .id(userId)
+            .build();
+
+        return promotionValidator.validate(user, promotionCashProduct.getPromotionTarget());
+    }
+}

--- a/api/src/main/java/org/yapp/domain/promotion/application/query/promotionValid/FirstPurchaseUserValidationStrategy.java
+++ b/api/src/main/java/org/yapp/domain/promotion/application/query/promotionValid/FirstPurchaseUserValidationStrategy.java
@@ -1,0 +1,24 @@
+package org.yapp.domain.promotion.application.query.promotionValid;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.yapp.core.domain.promotion.PromotionTarget;
+import org.yapp.core.domain.user.User;
+import org.yapp.domain.payment.application.PaymentHistoryService;
+
+@Component
+@RequiredArgsConstructor
+public class FirstPurchaseUserValidationStrategy implements PromotionValidationStrategy {
+
+    private final PaymentHistoryService paymentHistoryService;
+
+    @Override
+    public PromotionTarget getTarget() {
+        return PromotionTarget.FIRST_PURCHASE_USER;
+    }
+
+    @Override
+    public boolean isEligible(User user) {
+        return !paymentHistoryService.hasAnyPaymentHistory(user);
+    }
+}

--- a/api/src/main/java/org/yapp/domain/promotion/application/query/promotionValid/PromotionValidationStrategy.java
+++ b/api/src/main/java/org/yapp/domain/promotion/application/query/promotionValid/PromotionValidationStrategy.java
@@ -1,0 +1,12 @@
+package org.yapp.domain.promotion.application.query.promotionValid;
+
+import org.yapp.core.domain.promotion.PromotionTarget;
+import org.yapp.core.domain.user.User;
+
+public interface PromotionValidationStrategy {
+
+    PromotionTarget getTarget();
+
+
+    boolean isEligible(User user);
+}

--- a/api/src/main/java/org/yapp/domain/promotion/application/query/promotionValid/PromotionValidator.java
+++ b/api/src/main/java/org/yapp/domain/promotion/application/query/promotionValid/PromotionValidator.java
@@ -1,0 +1,30 @@
+package org.yapp.domain.promotion.application.query.promotionValid;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+import org.yapp.core.domain.promotion.PromotionTarget;
+import org.yapp.core.domain.user.User;
+
+
+@Component
+public class PromotionValidator {
+
+    private final Map<PromotionTarget, PromotionValidationStrategy> strategyMap;
+
+    public PromotionValidator(List<PromotionValidationStrategy> strategies) {
+        this.strategyMap = new EnumMap<>(PromotionTarget.class);
+        for (PromotionValidationStrategy strategy : strategies) {
+            this.strategyMap.put(strategy.getTarget(), strategy);
+        }
+    }
+
+    public boolean validate(User user, PromotionTarget target) {
+        PromotionValidationStrategy strategy = strategyMap.get(target);
+        if (strategy == null) {
+            throw new IllegalArgumentException("No strategy found for target: " + target);
+        }
+        return strategy.isEligible(user);
+    }
+}

--- a/api/src/main/java/org/yapp/domain/promotion/dao/PromotionCashProductRepository.java
+++ b/api/src/main/java/org/yapp/domain/promotion/dao/PromotionCashProductRepository.java
@@ -1,0 +1,16 @@
+package org.yapp.domain.promotion.dao;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.yapp.core.domain.promotion.PromotionCashProduct;
+
+@Repository
+public interface PromotionCashProductRepository extends JpaRepository<PromotionCashProduct, Long> {
+
+    List<PromotionCashProduct> findAllByStartDateBeforeAndEndDateAfterAndIsActive(
+        LocalDate startDateBefore, LocalDate endDateAfter,
+        Boolean isActive);
+
+}

--- a/api/src/main/java/org/yapp/domain/promotion/presentation/dto/response/PromotionCashProductResponse.java
+++ b/api/src/main/java/org/yapp/domain/promotion/presentation/dto/response/PromotionCashProductResponse.java
@@ -1,0 +1,15 @@
+package org.yapp.domain.promotion.presentation.dto.response;
+
+import org.yapp.domain.promotion.application.dto.PromotionCashProductQueryResult;
+
+public record PromotionCashProductResponse(
+    String uuid,
+    String cardImageUrl) {
+
+    public static PromotionCashProductResponse from(
+        PromotionCashProductQueryResult dto) {
+        return new PromotionCashProductResponse(
+            dto.uuid(),
+            dto.cardImageUrl());
+    }
+}

--- a/api/src/main/java/org/yapp/domain/user/application/UserService.java
+++ b/api/src/main/java/org/yapp/domain/user/application/UserService.java
@@ -180,4 +180,10 @@ public class UserService {
     public List<User> getAllUsers() {
         return userRepository.findAll();
     }
+
+    @Transactional(readOnly = true)
+    public Long getUserPuzzleCount(Long userId) {
+        User user = getUserById(userId);
+        return user.getPuzzleWallet() != null ? user.getPuzzleWallet().getPuzzleCount() : 0L;
+    }
 }

--- a/api/src/main/java/org/yapp/domain/user/presentation/UserController.java
+++ b/api/src/main/java/org/yapp/domain/user/presentation/UserController.java
@@ -20,8 +20,10 @@ import org.yapp.domain.user.presentation.dto.request.FcmTokenSaveRequest;
 import org.yapp.domain.user.presentation.dto.request.OauthUserDeleteRequest;
 import org.yapp.domain.user.presentation.dto.request.UserDeleteRequest;
 import org.yapp.domain.user.presentation.dto.response.UserBasicInfoResponse;
+import org.yapp.domain.user.presentation.dto.response.UserPuzzleResponse;
 import org.yapp.domain.user.presentation.dto.response.UserRejectHistoryResponse;
 import org.yapp.format.CommonResponse;
+
 
 @RestController
 @RequiredArgsConstructor
@@ -83,5 +85,16 @@ public class UserController {
         @RequestBody FcmTokenSaveRequest request) {
         userService.saveFcmToken(userId, request);
         return ResponseEntity.ok(CommonResponse.createSuccessWithNoContent());
+    }
+
+    @GetMapping("/puzzle")
+    @PreAuthorize(value = "hasAuthority('USER')")
+    @Operation(summary = "사용자 퍼즐 조회", description = "사용자의 현재 퍼즐 개수를 조회합니다.", tags = {"사용자"})
+    public ResponseEntity<CommonResponse<UserPuzzleResponse>> getUserPuzzle(
+        @AuthenticationPrincipal Long userId) {
+        Long puzzleCount = userService.getUserPuzzleCount(userId);
+        UserPuzzleResponse response = new UserPuzzleResponse(puzzleCount);
+
+        return ResponseEntity.ok(CommonResponse.createSuccess(response));
     }
 }

--- a/api/src/main/java/org/yapp/domain/user/presentation/dto/response/UserPuzzleResponse.java
+++ b/api/src/main/java/org/yapp/domain/user/presentation/dto/response/UserPuzzleResponse.java
@@ -1,0 +1,4 @@
+package org.yapp.domain.user.presentation.dto.response;
+
+public record UserPuzzleResponse(Long puzzleCount) {
+}

--- a/core/domain/src/main/java/org/yapp/core/domain/promotion/PromotionCashProduct.java
+++ b/core/domain/src/main/java/org/yapp/core/domain/promotion/PromotionCashProduct.java
@@ -1,0 +1,71 @@
+package org.yapp.core.domain.promotion;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.yapp.core.domain.BaseEntity;
+import org.yapp.core.domain.common.vo.Money;
+import org.yapp.core.domain.common.vo.Puzzle;
+
+@Entity
+@Table(name = "promotion_cash_products")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PromotionCashProduct extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "promotion_cash_product_id")
+    private Long id;
+
+    @Column(name = "uuid", nullable = false, unique = true)
+    private String uuid;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Embedded
+    private Money price;
+
+    @Column(name = "discount_rate", nullable = false, precision = 5, scale = 2)
+    private BigDecimal discountRate;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive;
+
+    @Column(name = "promotion_target", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private PromotionTarget promotionTarget;
+
+    @Embedded
+    @AttributeOverride(name = "count", column = @Column(name = "reward_puzzle_count"))
+    private Puzzle rewardPuzzle;
+
+    @Column(name = "card_image_url")
+    private String cardImageUrl;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    @PrePersist
+    private void prePersist() {
+        if (this.uuid == null) {
+            this.uuid = UUID.randomUUID().toString();
+        }
+    }
+}

--- a/core/domain/src/main/java/org/yapp/core/domain/promotion/PromotionTarget.java
+++ b/core/domain/src/main/java/org/yapp/core/domain/promotion/PromotionTarget.java
@@ -1,0 +1,13 @@
+package org.yapp.core.domain.promotion;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PromotionTarget {
+
+    FIRST_PURCHASE_USER("첫 구매 회원");
+
+    private final String description;
+}


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-1179](https://yapp25app3.atlassian.net/browse/PC-1179)

## ✨ 작업 내용
- 사용자의 재화 보유량을 확인할 수 있는 API 추가
- 상품 조회시 기본 상품과 프로모션 상품 리스트 모두 전달

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항

## 📋 참고 사항
- 코드 리뷰 시 논의가 필요한 사항이나 배포 관련 주의 사항을 추가합니다.
