### PR TITLE
[PC-1254] 나이별 가중치 적용

### DIFF
--- a/api/src/main/java/org/yapp/domain/match/application/algorithm/GreedyMatchAlgorithm.java
+++ b/api/src/main/java/org/yapp/domain/match/application/algorithm/GreedyMatchAlgorithm.java
@@ -22,76 +22,80 @@ import org.yapp.domain.match.application.algorithm.preference.PreferenceCalculat
 @Component
 public class GreedyMatchAlgorithm implements MatchAlgorithm {
 
-  private final MatchService matchService;
-  private final MatchBlocker matchBlocker;
-  private final PreferenceCalculatingPolicy preferenceCalculatingPolicy;
-
-  @Override
-  @Transactional
-  public List<Profile> doMatch(List<Profile> profiles) {
-    PriorityQueue<Edge> priorityEdges = getPriorityEdges(profiles);
-    Set<Long> matchedSet = greedyMatch(priorityEdges);
-    List<Profile> unmatchedProfiles = new ArrayList<>();
-    for (Profile profile : profiles) {
-      if (!matchedSet.contains(profile.getUser().getId())) {
-        unmatchedProfiles.add(profile);
-      }
-    }
-    return unmatchedProfiles;
-  }
-
-  private Set<Long> greedyMatch(PriorityQueue<Edge> priorityEdges) {
-    Set<Long> matchedSet = new HashSet<>();
-    while (!priorityEdges.isEmpty()) {
-      Edge edge = priorityEdges.poll();
-      if (matchedSet.contains(edge.user1Id) || matchedSet.contains(edge.user2Id)) {
-        continue;
-      }
-      matchedSet.add(edge.user1Id);
-      matchedSet.add(edge.user2Id);
-
-      matchService.createMatchInfo(edge.user1Id, edge.user2Id, false);
-    }
-    return matchedSet;
-  }
-
-  private PriorityQueue<Edge> getPriorityEdges(List<Profile> profiles) {
-    PriorityQueue<Edge> priorityEdgeQueue = new PriorityQueue<Edge>();
-    for (Profile profile1 : profiles) {
-      for (Profile profile2 : profiles) {
-        if (profile1.getId().equals(profile2.getId())) {
-          continue;
-        }
-        if (checkBlock(profile1, profile2)) {
-          continue;
-        }
-        int weight = calculateWeight(profile1.getId(), profile2.getId());
-        priorityEdgeQueue.add(
-            new Edge(weight, profile1.getUser().getId(), profile2.getUser().getId()));
-      }
-    }
-    return priorityEdgeQueue;
-  }
-
-  private boolean checkBlock(Profile blockingProfile, Profile blockedProfile) {
-    return matchBlocker.isBlocked(blockedProfile, blockingProfile) ||
-        matchBlocker.isBlocked(blockingProfile, blockedProfile);
-  }
-
-  private int calculateWeight(Long fromProfileId, Long toProfileId) {
-    return preferenceCalculatingPolicy.calculatePreference(fromProfileId, toProfileId);
-  }
-
-  @AllArgsConstructor
-  private static class Edge implements Comparable<Edge> {
-
-    private int weight;
-    private Long user1Id;
-    private Long user2Id;
+    private final MatchService matchService;
+    private final MatchBlocker matchBlocker;
+    private final List<PreferenceCalculatingPolicy> preferenceCalculatingPolicyChain;
 
     @Override
-    public int compareTo(Edge o) {
-      return o.weight - this.weight;
+    @Transactional
+    public List<Profile> doMatch(List<Profile> profiles) {
+        PriorityQueue<Edge> priorityEdges = getPriorityEdges(profiles);
+        Set<Long> matchedSet = greedyMatch(priorityEdges);
+        List<Profile> unmatchedProfiles = new ArrayList<>();
+        for (Profile profile : profiles) {
+            if (!matchedSet.contains(profile.getUser().getId())) {
+                unmatchedProfiles.add(profile);
+            }
+        }
+        return unmatchedProfiles;
     }
-  }
+
+    private Set<Long> greedyMatch(PriorityQueue<Edge> priorityEdges) {
+        Set<Long> matchedSet = new HashSet<>();
+        while (!priorityEdges.isEmpty()) {
+            Edge edge = priorityEdges.poll();
+            if (matchedSet.contains(edge.user1Id) || matchedSet.contains(edge.user2Id)) {
+                continue;
+            }
+            matchedSet.add(edge.user1Id);
+            matchedSet.add(edge.user2Id);
+
+            matchService.createMatchInfo(edge.user1Id, edge.user2Id, false);
+        }
+        return matchedSet;
+    }
+
+    private PriorityQueue<Edge> getPriorityEdges(List<Profile> profiles) {
+        PriorityQueue<Edge> priorityEdgeQueue = new PriorityQueue<Edge>();
+        for (Profile profile1 : profiles) {
+            for (Profile profile2 : profiles) {
+                if (profile1.getId().equals(profile2.getId())) {
+                    continue;
+                }
+                if (checkBlock(profile1, profile2)) {
+                    continue;
+                }
+                int weight = calculateWeight(profile1.getId(), profile2.getId());
+                priorityEdgeQueue.add(
+                    new Edge(weight, profile1.getUser().getId(), profile2.getUser().getId()));
+            }
+        }
+        return priorityEdgeQueue;
+    }
+
+    private boolean checkBlock(Profile blockingProfile, Profile blockedProfile) {
+        return matchBlocker.isBlocked(blockedProfile, blockingProfile) ||
+            matchBlocker.isBlocked(blockingProfile, blockedProfile);
+    }
+
+    private int calculateWeight(Long fromProfileId, Long toProfileId) {
+        int weight = 0;
+        for (PreferenceCalculatingPolicy preferenceCalculatingPolicy : preferenceCalculatingPolicyChain) {
+            weight += preferenceCalculatingPolicy.calculatePreference(fromProfileId, toProfileId);
+        }
+        return weight;
+    }
+
+    @AllArgsConstructor
+    private static class Edge implements Comparable<Edge> {
+
+        private int weight;
+        private Long user1Id;
+        private Long user2Id;
+
+        @Override
+        public int compareTo(Edge o) {
+            return o.weight - this.weight;
+        }
+    }
 }

--- a/api/src/main/java/org/yapp/domain/match/application/algorithm/preference/AgePreferenceCalculatingPolicy.java
+++ b/api/src/main/java/org/yapp/domain/match/application/algorithm/preference/AgePreferenceCalculatingPolicy.java
@@ -1,0 +1,39 @@
+package org.yapp.domain.match.application.algorithm.preference;
+
+import java.time.LocalDate;
+import java.time.Period;
+import lombok.RequiredArgsConstructor;
+import org.yapp.core.domain.profile.Profile;
+import org.yapp.core.domain.profile.ProfileBasic;
+import org.yapp.domain.profile.application.ProfileService;
+
+@RequiredArgsConstructor
+public class AgePreferenceCalculatingPolicy implements PreferenceCalculatingPolicy {
+
+    private static final int AGE_GAP = 4;
+    private static final int MAX_WEIGHT = 10;
+    private final ProfileService profileService;
+
+    @Override
+    public int calculatePreference(Long profile1Id, Long profile2Id) {
+        Profile profile1 = profileService.getProfileById(profile1Id);
+        Profile profile2 = profileService.getProfileById(profile2Id);
+
+        ProfileBasic profileBasic1 = profile1.getProfileBasic();
+        LocalDate birthDate1 = profileBasic1.getBirthdate();
+
+        ProfileBasic profileBasic2 = profile2.getProfileBasic();
+        LocalDate birthDate2 = profileBasic2.getBirthdate();
+
+        return calculateAgeWeight(birthDate1, birthDate2);
+    }
+
+    private int calculateAgeWeight(LocalDate birthDate1, LocalDate birthDate2) {
+        int ageDifference = Period.between(birthDate1, birthDate2).getYears();
+        int ageDifferenceAbs = Math.abs(ageDifference);
+        if (ageDifferenceAbs >= MAX_WEIGHT * 2) {
+            return -MAX_WEIGHT;
+        }
+        return MAX_WEIGHT - (ageDifferenceAbs / AGE_GAP) * AGE_GAP;
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
[PC-1254]
## ✨ 작업 내용
- 하루한번 매칭 시 가중치에 나이 차이에 따른 가중치를 적용하였습니다.
- 가중치 계산시 각 가중치 계산 로직을 순회하는 방식으로 변경하였습니다. 
## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
  
## 🎃 새롭게 알게된 사항

## 📋 참고 사항
- 코드 리뷰 시 논의가 필요한 사항이나 배포 관련 주의 사항을 추가합니다.


[PC-1254]: https://yapp25app3.atlassian.net/browse/PC-1254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ